### PR TITLE
Predicate Builder

### DIFF
--- a/src/Utilities/ExpressionExtension.cs
+++ b/src/Utilities/ExpressionExtension.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace ePiggyWeb.Utilities
+{
+    public static class ExpressionExtension
+    {
+        public static Expression<Func<T, bool>> Or<T>(this Expression<Func<T, bool>> expression1, Expression<Func<T, bool>> expression2)
+        {
+            return expression1.Compose(Expression.Or, expression2);
+        }
+
+        public static Expression<Func<T, bool>> And<T>(this Expression<Func<T, bool>> expression1, Expression<Func<T, bool>> expression2)
+        {
+            return expression1.Compose(Expression.And, expression2);
+        }
+
+        private static Expression<Func<T, bool>> Compose<T>(this Expression<Func<T, bool>> expression1,
+            Func<Expression, Expression, BinaryExpression> logicalOperation, Expression<Func<T, bool>> expression2)
+        {
+            var invokedExpression = Expression.Invoke(expression2, expression1.Parameters);
+            return Expression.Lambda<Func<T, bool>>(logicalOperation.Invoke(expression1.Body, invokedExpression), expression1.Parameters);
+        }
+    }
+}

--- a/src/Utilities/PredicateBuilder.cs
+++ b/src/Utilities/PredicateBuilder.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using ePiggyWeb.DataBase.Models;
+
+namespace ePiggyWeb.Utilities
+{
+    public static class PredicateBuilder
+    {
+        public static Expression<Func<IEntryModel, bool>> BuildEntryFilter(IEnumerable<int> idEnumerable, int userId)
+        {
+            if (idEnumerable is null)
+            {
+                return x => x.UserId == userId;
+            }
+
+            var idArray = idEnumerable as int[] ?? idEnumerable.ToArray();
+
+            if (!idArray.Any())
+            {
+                return x => x.UserId == userId;
+            }
+
+            Expression<Func<IEntryModel, bool>> filter = x => x.Id == idArray[0] && x.UserId == userId;
+
+            for (var i = 1; i <= idArray.Length; i++)
+            {
+                var i1 = i;
+                filter = filter.Or(x => x.Id == idArray[i1] && x.UserId == userId);
+            }
+
+            return filter;
+        }
+
+        public static Expression<Func<IGoalModel, bool>> BuildGoalFilter(IEnumerable<int> idEnumerable, int userId)
+        {
+            if (idEnumerable is null)
+            {
+                return x => x.UserId == userId;
+            }
+
+            var idArray = idEnumerable as int[] ?? idEnumerable.ToArray();
+
+            if (!idArray.Any())
+            {
+                return x => x.UserId == userId;
+            }
+
+            Expression<Func<IGoalModel, bool>> filter = x => x.Id == idArray[0] && x.UserId == userId;
+
+            for (var i = 1; i <= idArray.Length; i++)
+            {
+                var i1 = i;
+                filter = filter.Or(x => x.Id == idArray[i1] && x.UserId == userId);
+            }
+
+            return filter;
+        }
+    }
+}


### PR DESCRIPTION
Purpose: For more efficient deleting of many elements from database, instead of having many queries by every id, now we can call a single query and to look for all elements we want to find
ExpressionExtension:
Extension methods for Expression, used two add two predicates together into a single one, for only for And/Or logical operators
PredicateBuilder: Used for specific predicate building, at the moment it's used to create predicates for deleting or searching elements in database
This should fulfill at least in part the Generics requirement