### PR TITLE
General improvements for mobile devices

### DIFF
--- a/src/DataManagement/MonthlyReport/MonthlyReportCalculator.cs
+++ b/src/DataManagement/MonthlyReport/MonthlyReportCalculator.cs
@@ -34,7 +34,7 @@ namespace ePiggyWeb.DataManagement.MonthlyReport
         }
 
         public async Task<MonthlyReportResult> Calculate()
-        { 
+        {
             Result = await GatherDataAsync();
             CalculateBiggestExpensesCategory();
             Result.SavedUpGoals = CalculateSavedUpGoals();
@@ -67,16 +67,12 @@ namespace ePiggyWeb.DataManagement.MonthlyReport
         private void CalculateBiggestExpensesCategory()
         {
             var enumCount = Enum.GetValues(typeof(Importance)).Length;
-            var biggestCategory = (Importance) enumCount;
+            var biggestCategory = (Importance)enumCount;
             var sum = 0m;
             foreach (var importance in Enum.GetValues(typeof(Importance)).Cast<Importance>())
             {
-                var temp = 0M;
                 var expenses = Expenses.GetBy(importance);
-                foreach (var entry in expenses) //not linq since when empty category it crashes
-                {
-                    temp += entry.Amount;
-                }
+                var temp = expenses.Sum(entry => entry.Amount);
                 if (temp < sum) continue;
                 sum = temp;
                 biggestCategory = importance;
@@ -120,15 +116,15 @@ namespace ePiggyWeb.DataManagement.MonthlyReport
                     maxGoal = (Goal)item;
                 }
 
-                if (item.Amount > min || item.Amount <= AllSavings ) continue;
+                if (item.Amount > min || item.Amount <= AllSavings) continue;
                 min = item.Amount;
-                minGoal = (Goal) item;
+                minGoal = (Goal)item;
             }
 
             Result.CheapestGoal = minGoal;
             Result.MostExpensiveGoal = maxGoal;
 
-            Result.MonthsForCheapestGoal = (int) decimal.Ceiling((minGoal.Amount - AllSavings) / Balance);
+            Result.MonthsForCheapestGoal = (int)decimal.Ceiling((minGoal.Amount - AllSavings) / Balance);
             Result.MonthsForMostExpensiveGoal = (int)decimal.Ceiling((maxGoal.Amount - AllSavings) / Balance);
 
         }

--- a/src/DataManagement/MonthlyReport/MonthlyReportCalculator.cs
+++ b/src/DataManagement/MonthlyReport/MonthlyReportCalculator.cs
@@ -117,8 +117,8 @@ namespace ePiggyWeb.DataManagement.MonthlyReport
             Result.CheapestGoal = minGoal;
             Result.MostExpensiveGoal = maxGoal;
 
-            Result.MonthsForCheapestGoal = (int) decimal.Ceiling(minGoal.Amount - AllSavings / savedThisMonth);
-            Result.MonthsForMostExpensiveGoal = (int)decimal.Ceiling(maxGoal.Amount - AllSavings / savedThisMonth);
+            Result.MonthsForCheapestGoal = (int) decimal.Ceiling((minGoal.Amount - AllSavings) / savedThisMonth);
+            Result.MonthsForMostExpensiveGoal = (int)decimal.Ceiling((maxGoal.Amount - AllSavings) / savedThisMonth);
 
         }
     }

--- a/src/DataManagement/MonthlyReport/MonthlyReportCalculator.cs
+++ b/src/DataManagement/MonthlyReport/MonthlyReportCalculator.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using ePiggyWeb.DataBase;
+using ePiggyWeb.DataManagement.Entries;
+using ePiggyWeb.DataManagement.Goals;
+using ePiggyWeb.Utilities;
+
+namespace ePiggyWeb.DataManagement.MonthlyReport
+{
+    public class MonthlyReportCalculator
+    {
+        private int UserId { get; }
+        private GoalDatabase GoalDatabase { get; }
+        private EntryDatabase EntryDatabase { get; }
+
+        private IEntryList Expenses { get; set; }
+        private IEntryList Income { get; set; }
+        private IGoalList Goals { get; set; }
+
+        private MonthlyReportResult Result { get; set; }
+
+
+
+        public MonthlyReportCalculator(GoalDatabase goalDatabase, EntryDatabase entryDatabase, int userId)
+        {
+            GoalDatabase = goalDatabase;
+            EntryDatabase = entryDatabase;
+            UserId = userId;
+        }
+
+        public async Task<MonthlyReportResult> Calculate()
+        { 
+            Result = await GatherDataAsync();
+            CalculateBiggestExpensesCategory();
+            return Result;
+        }
+
+        private async Task<MonthlyReportResult> GatherDataAsync()
+        {
+            var today = DateTime.Today;
+            var month = new DateTime(today.Year, today.Month, 1);
+            var first = month.AddMonths(-1);
+            var last = month.AddDays(-1);
+            Debug.WriteLine(first);
+            Debug.WriteLine(last);
+            Expenses = (await EntryDatabase.ReadListAsync(UserId, EntryType.Expense)).GetFrom(first).GetTo(last);
+            Income = (await EntryDatabase.ReadListAsync(UserId, EntryType.Income)).GetFrom(first).GetTo(last);
+            Goals = await GoalDatabase.ReadListAsync(UserId);
+            return new MonthlyReportResult(Expenses.GetSum(), Income.GetSum(), first, last);
+
+        }
+
+        private void CalculateBiggestExpensesCategory()
+        {
+            var enumCount = Enum.GetValues(typeof(Importance)).Length;
+            var biggestCategory = (Importance) enumCount;
+            var sum = 0m;
+            for (var i = enumCount; i > (int) Importance.Necessary; i--)
+            {
+                var temp = 0M;
+                var expenses = Expenses.GetBy((Importance)i);
+                foreach (var entry in expenses)
+                {
+                    temp += entry.Amount;
+                }
+                if (temp < sum) continue;
+                sum = temp;
+                biggestCategory = (Importance)i;
+            }
+
+            Result.BiggestCategory = biggestCategory;
+            Result.BiggestCategorySum = sum;
+            var necessarySum = Expenses.GetBy(Importance.Necessary).Sum(entry => entry.Amount);
+            Result.NecessarySum = necessarySum;
+            Result.HowMuchBigger = ((sum - necessarySum) / necessarySum * 100);
+        }
+    }
+}

--- a/src/DataManagement/MonthlyReport/MonthlyReportResult.cs
+++ b/src/DataManagement/MonthlyReport/MonthlyReportResult.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using ePiggyWeb.DataManagement.Goals;
 using ePiggyWeb.Utilities;
 
 namespace ePiggyWeb.DataManagement.MonthlyReport
@@ -12,15 +13,23 @@ namespace ePiggyWeb.DataManagement.MonthlyReport
         public DateTime End { get; set; }
         public decimal Expenses { get; set; }
         public decimal Income { get; set; }
+        public decimal Balance { get; set; }
         public Importance BiggestCategory { get; set; }
         public decimal BiggestCategorySum { get; set; }
         public decimal NecessarySum { get; set; }
         public decimal HowMuchBigger { get; set; }
+        public List<IGoal> SavedUpGoals { get; set; }
+        public bool HasGoals { get; set; }
+        public IGoal MostExpensiveGoal { get; set; }
+        public int MonthsForMostExpensiveGoal { get; set; }
+        public IGoal CheapestGoal { get; set; }
+        public int MonthsForCheapestGoal { get; set; }
 
-        public MonthlyReportResult(decimal expenses, decimal income, DateTime start, DateTime end)
+        public MonthlyReportResult(decimal expenses, decimal income, decimal balance, DateTime start, DateTime end)
         {
             Expenses = expenses;
             Income = income;
+            Balance = balance;
             Start = start;
             End = end;
         }

--- a/src/DataManagement/MonthlyReport/MonthlyReportResult.cs
+++ b/src/DataManagement/MonthlyReport/MonthlyReportResult.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ePiggyWeb.Utilities;
+
+namespace ePiggyWeb.DataManagement.MonthlyReport
+{
+    public class MonthlyReportResult
+    {
+        public DateTime Start { get; set; }
+        public DateTime End { get; set; }
+        public decimal Expenses { get; set; }
+        public decimal Income { get; set; }
+        public Importance BiggestCategory { get; set; }
+        public decimal BiggestCategorySum { get; set; }
+        public decimal NecessarySum { get; set; }
+        public decimal HowMuchBigger { get; set; }
+
+        public MonthlyReportResult(decimal expenses, decimal income, DateTime start, DateTime end)
+        {
+            Expenses = expenses;
+            Income = income;
+            Start = start;
+            End = end;
+        }
+    }
+}

--- a/src/Pages/ChangePassword.cshtml
+++ b/src/Pages/ChangePassword.cshtml
@@ -2,7 +2,7 @@
 @using System.Security.Claims
 @model ePiggyWeb.Pages.ChangePasswordModel
 
-<div class="container login-container bg-primary border">
+<div class="container login-container bg-primary border col-lg-6 col-md-8 col-sm-10 col-11 mt-5">
     
     @if (!Request.Cookies.ContainsKey("snow"))
     {

--- a/src/Pages/ChangePassword.cshtml
+++ b/src/Pages/ChangePassword.cshtml
@@ -7,13 +7,13 @@
         @if (!Request.Cookies.ContainsKey("snow"))
         {
             <form method="post" asp-controller="Snow" asp-action="StartSnow" asp-route-returnUrl="@Request.Path">
-                <button class="btn btn-outline-light">I'm feeling Christmas!</button>
+                <button class="btn btn-outline-light">I'm feeling Christmas!<i class="ml-1 fas fa-snowflake"></i></button>
             </form>
         }
         else
         {
             <form method="post" asp-controller="Snow" asp-action="StopSnow" asp-route-returnUrl="@Request.Path">
-                <button class="btn btn-outline-light">I don't feel Christmas!</button>
+                <button class="btn btn-outline-light">I don't feel Christmas!<i class="ml-1 fas fa-snowplow"></i></button>
             </form>
         }
         <h3 class="text-light">Change Password</h3>
@@ -33,7 +33,7 @@
             <input class="btn btn-outline-warning" type="submit" value="Confirm" />
             <p class="text-warning">@Model.ErrorMessage</p>
             <hr />
-            <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#ConfirmModal">Delete Account</button>
+            <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#ConfirmModal">Delete Account<i class="ml-1 fas fa-user-times"></i></button>
         </form>
     </div>
 </div>

--- a/src/Pages/ChangePassword.cshtml
+++ b/src/Pages/ChangePassword.cshtml
@@ -2,7 +2,7 @@
 @using System.Security.Claims
 @model ePiggyWeb.Pages.ChangePasswordModel
 
-<div class="container login-container bg-primary border col-lg-6 col-md-8 col-sm-10 col-11 mt-5">
+<div class="container login-container bg-primary border col-lg-4 col-md-8 col-sm-10 col-11 mt-5">
     
     @if (!Request.Cookies.ContainsKey("snow"))
     {

--- a/src/Pages/ChangePassword.cshtml
+++ b/src/Pages/ChangePassword.cshtml
@@ -2,39 +2,40 @@
 @using System.Security.Claims
 @model ePiggyWeb.Pages.ChangePasswordModel
 
-<div class="container login-container bg-primary border col-lg-4 col-md-8 col-sm-10 col-11 mt-5">
-    
-    @if (!Request.Cookies.ContainsKey("snow"))
-    {
-        <form method="post" asp-controller="Snow" asp-action="StartSnow" asp-route-returnUrl="@Request.Path">
-            <button class="btn btn-outline-light">I'm feeling Christmas!</button>
+<div class="container login-container col-lg-4 col-md-8 col-sm-10 col-11 mt-5">
+    <div class="login-form-2 bg-primary border">
+        @if (!Request.Cookies.ContainsKey("snow"))
+        {
+            <form method="post" asp-controller="Snow" asp-action="StartSnow" asp-route-returnUrl="@Request.Path">
+                <button class="btn btn-outline-light">I'm feeling Christmas!</button>
+            </form>
+        }
+        else
+        {
+            <form method="post" asp-controller="Snow" asp-action="StopSnow" asp-route-returnUrl="@Request.Path">
+                <button class="btn btn-outline-light">I don't feel Christmas!</button>
+            </form>
+        }
+        <h3 class="text-light">Change Password</h3>
+        <p class="text-light">User: @User.FindFirst(ClaimTypes.Email).Value</p>
+        <form method="post">
+            <label class="text-light">New password</label>
+            <div class="form-group">
+                <input asp-for="Password" type="password" />
+            </div>
+            <label class="text-light">Confirm password</label>
+            <div class="form-group">
+                <input asp-for="PasswordConfirm" type="password" />
+            </div>
+            <div class="form-group">
+                <span asp-validation-for="Password" class="text-warning"></span>
+            </div>
+            <input class="btn btn-outline-warning" type="submit" value="Confirm" />
+            <p class="text-warning">@Model.ErrorMessage</p>
+            <hr />
+            <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#ConfirmModal">Delete Account</button>
         </form>
-    }
-    else
-    {
-        <form method="post" asp-controller="Snow" asp-action="StopSnow" asp-route-returnUrl="@Request.Path">
-            <button class="btn btn-outline-light">I don't feel Christmas!</button>
-        </form>
-    }
-    <h3 class="text-light">Change Password</h3>
-    <p class="text-light">User: @User.FindFirst(ClaimTypes.Email).Value</p>
-    <form method="post">
-        <label class="text-light">New password</label>
-        <div class="form-group">
-            <input asp-for="Password" type="password" />
-        </div>
-        <label class="text-light">Confirm password</label>
-        <div class="form-group">
-            <input asp-for="PasswordConfirm" type="password" />
-        </div>
-        <div class="form-group">
-            <span asp-validation-for="Password" class="text-warning"></span>
-        </div>
-        <input class="btn btn-outline-warning" type="submit" value="Confirm" />
-        <p class="text-warning">@Model.ErrorMessage</p>
-        <hr/>
-        <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#ConfirmModal">Delete Account</button>
-    </form>
+    </div>
 </div>
 
 <!-- Modal -->

--- a/src/Pages/ComparisonGraph.cshtml
+++ b/src/Pages/ComparisonGraph.cshtml
@@ -14,11 +14,13 @@ else
 {
     <form method="get" class="mt-5">
         <input type="hidden" name="handler" value="Filter" />
-        <label class="text-light">Period:</label>
-        <input for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
-        <label class="text-light"> - </label>
-        <input for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
-        <input type="submit" value="Filter" class="btn btn-warning ml-5" />
+        <label class="text-light col-md-4">Period:</label>
+        <div class="row justify-content-center">
+            <input class="col-md-3 col-sm-5 col-5" for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
+            <label class="text-light ml-2 mr-2"> - </label>
+            <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
+        </div>
+        <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
 }

--- a/src/Pages/ComparisonGraph.cshtml
+++ b/src/Pages/ComparisonGraph.cshtml
@@ -20,7 +20,7 @@ else
             <label class="text-light ml-2 mr-2"> - </label>
             <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
         </div>
-        <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
+        <button type="submit" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3">Filter<i class="fas fa-filter"></i></button>
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
 }

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -99,66 +99,68 @@ else
 <div class="row">
     <div class="col-12 border mt-3 mb-3">
         <form method="post">
+            <input asp-page-handler="Delete" type="submit" class="btn btn-sm btn-danger" value="Delete" />
             @if (Model.Expenses.Any())
             {
-                <table class="table table-hover border-primary table-bordered">
-                    <tr class="table-primary">
-                        <th>
-                            <label asp-for="Expenses.FirstOrDefault().Title"></label>
-                        </th>
-                        <th style="width: 18%">
-                            <label asp-for="Expenses.FirstOrDefault().Amount"></label>
-                        </th>
-                        <th style="width: 10%">
-                            <label asp-for="Expenses.FirstOrDefault().Date"></label>
-                        </th>
-                        <th style="width: 15%">
-                            <label asp-for="Expenses.FirstOrDefault().Importance"></label>
-                        </th>
-                        <th style="width: 5%">
-                            <label asp-for="Expenses.FirstOrDefault().Recurring"></label>
-                        </th>
-                        <th style="width: 15%">
+                <div class="table-responsive-sm">
+            <table class="table table-hover border-primary table-bordered">
+                <tr class="table-primary">
+                    <th scope="col">
+                        <label asp-for="Expenses.FirstOrDefault().Title"></label>
+                    </th>
+                    <th scope="col">
+                        <label asp-for="Expenses.FirstOrDefault().Amount"></label>
+                    </th>
+                    <th scope="col">
+                        <label asp-for="Expenses.FirstOrDefault().Date"></label>
+                    </th>
+                    <th scope="col">
+                        <label asp-for="Expenses.FirstOrDefault().Importance"></label>
+                    </th>
+                    <th scope="col">
+                        <label asp-for="Expenses.FirstOrDefault().Recurring"></label>
+                    </th>
+                    <th scope="col">
 
-                        </th>
+                    </th>
 
+                </tr>
+
+                @foreach (var item in Model.Expenses.OrderByDescending(x => x.Date))
+                {
+                    <tr class="table-light border-primary">
+                        <td class="border-primary text-nowrap">
+                            @Html.DisplayFor(m => item.Title)
+                        </td>
+                        <td class="border-primary text-nowrap">
+                            @NumberFormatter.FormatCurrency(item.Amount)
+                        </td>
+                        <td class="border-primary text-nowrap">
+                            @item.Date.ToShortDateString()
+                            <!--Html.DisplayFor(m => item.Date)-->
+                        </td>
+                        <td class="border-primary text-nowrap">
+                            @((Importance) item.Importance)
+                        </td>
+                        <td class="border-primary text-nowrap">
+                            @if (item.Recurring)
+                            {
+                                <i class="fas fa-check text-success"></i>
+                            }
+                        </td>
+                        <td class="border-primary text-nowrap">
+                            <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="2" class="btn btn-sm btn-success">Edit </a>
+                        </td>
                     </tr>
-
-                    @foreach (var item in Model.Expenses.OrderByDescending(x => x.Date))
-                    {
-                        <tr class="table-light border-primary">
-                            <td class="border-primary">
-                                @Html.DisplayFor(m => item.Title)
-                            </td>
-                            <td class="border-primary">
-                                @NumberFormatter.FormatCurrency(item.Amount)
-                            </td>
-                            <td class="border-primary">
-                                @item.Date.ToShortDateString()
-                                <!--Html.DisplayFor(m => item.Date)-->
-                            </td>
-                            <td class="border-primary">
-                                @((Importance)item.Importance)
-                            </td>
-                            <td class="border-primary">
-                                @if (item.Recurring)
-                                {
-                                    <i class="fas fa-check text-success"></i>
-                                }
-                            </td>
-                            <td class="border-primary">
-                                <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="2" class="btn btn-sm btn-success">Edit </a>
-                                <input asp-page-handler="Delete" asp-route-id="@item.Id" type="submit" class="btn btn-sm btn-danger" value="Delete" />
-                            </td>
-                        </tr>
+                }
+            </table>
+            </div>
                     }
-                </table>
-            }
-            else
-            {
-                <p>No expenses available</p>
-            }
-        </form>
+                    else
+                    {
+                    <p>No expenses available</p>
+                    }
+            </form>
     </div>
 </div>
 

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -112,7 +112,7 @@ else
                     {
                         <tr class="table-light border-primary">
                             <td class="border-primary border entry-table-side">
-                                <input name="chkEntry" type="checkbox" value="@item.Id"/>
+                                <input class="bigger" name="chkEntry" type="checkbox" value="@item.Id" />
                             </td>
                             <td class=" border-right-0 border-primary text-nowrap entry-column">
                                 <div class="row">

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -41,11 +41,13 @@ else
 
     <form method="get" class="mt-5">
         <input type="hidden" name="handler" value="Filter" />
-        <label class="text-light">Period:</label>
-        <input for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
-        <label class="text-light"> - </label>
-        <input for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
-        <input type="submit" value="Filter" class="btn btn-warning ml-5" />
+        <label class="text-light col-md-4">Period:</label>
+        <div class="row justify-content-center">
+            <input class="col-md-3 col-sm-5 col-5" for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
+            <label class="text-light ml-2 mr-2"> - </label>
+            <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
+        </div>
+        <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
 }

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -92,10 +92,74 @@ else
     <h5 class="text-light">Spent this period: @NumberFormatter.FormatCurrency(Model.Expenses.GetSum())</h5>
     <h5 class="text-light">All expenses: @NumberFormatter.FormatCurrency(Model.AllExpenses)</h5>
     <hr class="mt-4 mb-4" />
-    
+
 }
 
+<div class="row">
+    <div class="col-12 border mt-3 mb-3">
+        <form method="post">
+            @if (Model.Expenses.Any())
+            {
+                <table class="table table-hover border-primary table-bordered">
+                    <tr class="table-primary">
+                        <th scope="col">
 
+                        </th>
+                        <th scope="col">
+                            Expenses
+                        </th>
+                        <th scope="col">
+                            Edit
+                        </th>
+                    </tr>
+                    @foreach (var item in Model.Expenses.OrderByDescending(x => x.Date))
+                    {
+                        <tr class="table-light border-primary">
+                            <td class="border-primary entry-table-side">
+                                <input type="checkbox"/>
+                            </td>
+                            <td class="border-primary text-nowrap entry-column">
+                                <div class="row">
+                                    <div class="col-12 mb-2">
+                                        <strong class="text-info">
+                                            @Html.DisplayFor(m => item.Title)
+                                        </strong>
+                                    </div>
+                                    <div class="col-12 col-md-5 col-lg-4">
+                                        <span class="text-info">Amount:</span>
+                                        @NumberFormatter.FormatCurrency(item.Amount)
+                                    </div>
+                                    <div class="col-12 col-md-3 col-lg-2">
+                                        <span class="text-info">Date: </span>
+                                        @item.Date.ToShortDateString()
+                                    </div>
+                                    <div class="col-12 col-md-4">
+                                        <span class="text-info">Importance: </span>
+                                        @((Importance) item.Importance)
+                                    </div>
+                                    <div class="col-12 col-md-4 col-lg-2">
+                                        <span class="text-info">Recurring: </span>
+                                        @if (item.Recurring)
+                                        {
+                                            <i class="fas fa-check text-success"></i>
+                                        }
+                                    </div>
+
+                                </div>
+                            </td>
+                            <td class="border-primary entry-table-side">
+                                <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="2" class="btn btn-sm btn-success">Edit </a>
+                                <input asp-page-handler="Delete" asp-route-id="@item.Id" type="submit" class="btn btn-sm btn-danger" value="Delete" />
+                            </td>
+                        </tr>
+                    }
+                </table>
+            }
+        </form>
+    </div>
+</div>
+
+<!--
 <div class="row">
     <div class="col-12 border mt-3 mb-3">
         <form method="post">
@@ -137,31 +201,30 @@ else
                         </td>
                         <td class="border-primary text-nowrap">
                             @item.Date.ToShortDateString()
-                            <!--Html.DisplayFor(m => item.Date)-->
                         </td>
-                        <td class="border-primary text-nowrap">
-                            @((Importance) item.Importance)
-                        </td>
-                        <td class="border-primary text-nowrap">
-                            @if (item.Recurring)
-                            {
-                                <i class="fas fa-check text-success"></i>
-                            }
-                        </td>
-                        <td class="border-primary text-nowrap">
-                            <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="2" class="btn btn-sm btn-success">Edit </a>
-                        </td>
+<td class="border-primary text-nowrap">
+    @((Importance) item.Importance)
+</td>
+<td class="border-primary text-nowrap">
+    @if (item.Recurring)
+    {
+        <i class="fas fa-check text-success"></i>
+    }
+</td>
+<td class="border-primary text-nowrap">
+    <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="2" class="btn btn-sm btn-success">Edit </a>
+</td>
                     </tr>
-                }
+}
             </table>
             </div>
-                    }
-                    else
-                    {
-                    <p>No expenses available</p>
-                    }
+}
+else
+{
+<p>No expenses available</p>
+}
             </form>
     </div>
 </div>
-
+-->
 

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -143,7 +143,7 @@ else
 
                                 </div>
                             </td>
-                            <td class="border-left-0 border-primary entry-table-side">
+                            <td class="border-primary border-left-0 entry-table-side">
                                 <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="2" class="btn btn-sm btn-outline-success"><i class="far fa-edit"></i> </a>
                                 <!--<input asp-page-handler="Delete" asp-route-id="@item.Id" type="submit" class="btn btn-sm btn-outline-danger" value="x" />-->
                             </td>

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -98,11 +98,11 @@ else
 <form method="post">
 <input asp-page-handler="Delete" type="submit" class="btn btn-danger" value="Delete Selected"/>
 
-<div class="row">
-    <div class="col-12 mt-3 mb-3">
+<div class="row ml-2 mr-2 mt-3 mb-3">
+    <div class="container border col-12 p-0">
         @if (Model.Expenses.Any())
             {
-                <table class="table table-hover border-primary">
+                <table class="table table-hover mb-0">
                     <tr class="bg-primary">
                         <th colspan="3" scope="col">
                             <h5 class="text-light">Expenses</h5>

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -96,15 +96,18 @@ else
 }
 
 <form method="post">
-<input asp-page-handler="Delete" type="submit" class="btn btn-danger" value="Delete Selected"/>
+    <input asp-page-handler="Delete" type="submit" class="btn btn-danger" value="Delete Selected"/>
 
-<div class="row ml-2 mr-2 mt-3 mb-3">
-    <div class="container border col-12 p-0">
-        @if (Model.Expenses.Any())
+    <div class="row ml-2 mr-2 mt-3 mb-3">
+        <div class="container border col-12 p-0">
+            @if (Model.Expenses.Any())
             {
                 <table class="table table-hover mb-0">
                     <tr class="bg-primary">
-                        <th colspan="3" scope="col">
+                        <th class="border-right entry-table-side" scope="col">
+                            <input class="bigger" type="checkbox" onClick="toggle(this)"/><br/>
+                        </th>
+                        <th colspan="2" scope="col">
                             <h5 class="text-light">Expenses</h5>
                         </th>
                     </tr>
@@ -152,75 +155,17 @@ else
                 </table>
             }
        
+        </div>
     </div>
-</div>
 </form>
-<!--
-<div class="row">
-    <div class="col-12 border mt-3 mb-3">
-        <form method="post">
-            <input asp-page-handler="Delete" type="submit" class="btn btn-sm btn-danger" value="Delete" />
-            @if (Model.Expenses.Any())
-            {
-                <div class="table-responsive-sm">
-            <table class="table table-hover border-primary table-bordered">
-                <tr class="table-primary">
-                    <th scope="col">
-                        <label asp-for="Expenses.FirstOrDefault().Title"></label>
-                    </th>
-                    <th scope="col">
-                        <label asp-for="Expenses.FirstOrDefault().Amount"></label>
-                    </th>
-                    <th scope="col">
-                        <label asp-for="Expenses.FirstOrDefault().Date"></label>
-                    </th>
-                    <th scope="col">
-                        <label asp-for="Expenses.FirstOrDefault().Importance"></label>
-                    </th>
-                    <th scope="col">
-                        <label asp-for="Expenses.FirstOrDefault().Recurring"></label>
-                    </th>
-                    <th scope="col">
 
-                    </th>
-
-                </tr>
-
-                @foreach (var item in Model.Expenses.OrderByDescending(x => x.Date))
-                {
-                    <tr class="table-light border-primary">
-                        <td class="border-primary text-nowrap">
-                            @Html.DisplayFor(m => item.Title)
-                        </td>
-                        <td class="border-primary text-nowrap">
-                            @NumberFormatter.FormatCurrency(item.Amount)
-                        </td>
-                        <td class="border-primary text-nowrap">
-                            @item.Date.ToShortDateString()
-                        </td>
-<td class="border-primary text-nowrap">
-    @((Importance) item.Importance)
-</td>
-<td class="border-primary text-nowrap">
-    @if (item.Recurring)
-    {
-        <i class="fas fa-check text-success"></i>
+    
+<script language="JavaScript">
+    function toggle(source) {
+        checkboxes = document.getElementsByName('chkEntry');
+        for(var i=0, n=checkboxes.length;i<n;i++) {
+            checkboxes[i].checked = source.checked;
+        }
     }
-</td>
-<td class="border-primary text-nowrap">
-    <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="2" class="btn btn-sm btn-success">Edit </a>
-</td>
-                    </tr>
-}
-            </table>
-            </div>
-}
-else
-{
-<p>No expenses available</p>
-}
-            </form>
-    </div>
-</div>
--->
+</script>
 

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -97,7 +97,7 @@ else
 
 
 <div class="row">
-    <div class="col-10 border mt-3 mb-3">
+    <div class="col-12 border mt-3 mb-3">
         <form method="post">
             @if (Model.Expenses.Any())
             {
@@ -159,9 +159,6 @@ else
                 <p>No expenses available</p>
             }
         </form>
-    </div>
-    <div class="col-2 border p-3 mt-3 mb-3">
-       
     </div>
 </div>
 

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -16,30 +16,68 @@ else
     <div class="container p-0 mt-3">
         <h2 class="text-info">Expenses</h2>
     </div>
+    <hr class="mt-4 mb-4" />
 
-    <form method="post" asp-page-handler="NewEntry">
-        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-        <input asp-for="Title" type="text" placeholder="Title" value="" />
+    @if (!ModelState.IsValid)
+    {
+        <div class="container">
+            <div class="alert alert-danger alert-dismissible fade show mt-2" role="alert">
+                <strong>Holy guacamole!</strong> Expense was not added, because wrong info was provided.
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+        </div>
+    }
+    <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#addEntryCollapse" aria-expanded="false" aria-controls="collapseExample">
+        Add Expense
+    </button>
+    <div class="collapse mt-3" id="addEntryCollapse">
+        <form method="post" asp-page-handler="NewEntry">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="container">
+                <div class="row justify-content-center p-0">
+                    <div class="col-12 col-md-4 col-lg-3 mb-1">
+                        <input asp-for="Title" type="text" placeholder="Title" value="" />
+                    </div>
+                    <div class="col-12 col-md-4 col-lg-3 mb-1">
+                        <input asp-for="Amount" type="text" placeholder="Amount" value="" />
+                    </div>
+                    <div class="col-12 col-md-4 col-lg-3 mb-1">
+                        <input asp-for="Date" type="date" value="@DateTime.Now.ToShortDateString()" />
+                    </div>
+                </div>
+                <div class="row justify-content-center mb-3">
+                    <div class="col-12 col-md-3 col-lg-2">
+                        <select asp-for="Importance">
+                            <option hidden disabled selected value="">Importance</option>
+                            <option value="1">Necessary</option>
+                            <option value="2">High</option>
+                            <option value="3">Medium</option>
+                            <option value="4">Low</option>
+                            <option value="5">Unnecessary</option>
+                        </select>
+                    </div>
+                    <div class="col-12 col-md-3 col-lg-2">
+                        <label class="text-light">Is Monthly?</label>
+                        <input asp-for="Recurring" type="checkbox" placeholder="" />
+                    </div>
+                </div>
+                <div class="container col-12 col-md-4 col-lg-3">
+                    <input type="submit" value="Add" class="btn btn-primary" />
+                    <input class="btn btn-danger" type="reset" value="Reset">
+                </div>
+            </div>
+        </form>
+    </div>
+    <div class="container mt-3">
         <span asp-validation-for="Title" class="text-danger"></span>
-        <input asp-for="Amount" type="text" placeholder="Amount" value="" />
         <span asp-validation-for="Amount" class="text-danger"></span>
-        <input asp-for="Date" type="date" value="@DateTime.Now.ToShortDateString()" />
-        <select asp-for="Importance" class="ml-3">
-            <option hidden disabled selected value="">Importance</option>
-            <option value="1">Necessary</option>
-            <option value="2">High</option>
-            <option value="3">Medium</option>
-            <option value="4">Low</option>
-            <option value="5">Unnecessary</option>
-        </select>
         <span asp-validation-for="Importance" class="text-danger"></span>
-        <label class="text-light ml-3">Is Monthly?</label>
-        <input asp-for="Recurring" type="checkbox" placeholder="" />
-        <input type="submit" value="Add" class="btn btn-primary ml-5" />
-        <input class="btn btn-danger ml-2" type="reset" value="Reset">
-    </form>
+    </div>
 
-    <form method="get" class="mt-5">
+    <hr class="mt-4 mb-4" />
+    <form method="get">
         <input type="hidden" name="handler" value="Filter" />
         <label class="text-light col-md-4">Period:</label>
         <div class="row justify-content-center">
@@ -50,20 +88,13 @@ else
         <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
+    <hr class="mt-4 mb-4" />
+    <h5 class="text-light">Spent this period: @NumberFormatter.FormatCurrency(Model.Expenses.GetSum())</h5>
+    <h5 class="text-light">All expenses: @NumberFormatter.FormatCurrency(Model.AllExpenses)</h5>
+    <hr class="mt-4 mb-4" />
+    
 }
 
-
-@if (!ModelState.IsValid)
-{
-    <div class="container">
-        <div class="alert alert-danger alert-dismissible fade show mt-2" role="alert">
-            <strong>Holy guacamole!</strong> Expense was not added, because wrong info was provided.
-            <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-            </button>
-        </div>
-    </div>
-}
 
 <div class="row">
     <div class="col-10 border mt-3 mb-3">
@@ -130,8 +161,7 @@ else
         </form>
     </div>
     <div class="col-2 border p-3 mt-3 mb-3">
-        <p class="text-light">Spent this period: @NumberFormatter.FormatCurrency(Model.Expenses.GetSum())</p>
-        <p class="text-light">All expenses: @NumberFormatter.FormatCurrency(Model.AllExpenses)</p>
+       
     </div>
 </div>
 

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -30,7 +30,7 @@ else
         </div>
     }
     <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#addEntryCollapse" aria-expanded="false" aria-controls="collapseExample">
-        Add Expense
+        Add Expense<i class=" ml-1 fas fa-pencil-alt"></i>
     </button>
     <div class="collapse mt-3" id="addEntryCollapse">
         <form method="post" asp-page-handler="NewEntry">
@@ -85,7 +85,7 @@ else
             <label class="text-light ml-2 mr-2"> - </label>
             <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
         </div>
-        <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
+        <button type="submit" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3">Filter<i class="fas fa-filter"></i></button>
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
     <hr class="mt-4 mb-4" />
@@ -96,8 +96,9 @@ else
 }
 
 <form method="post">
-    <input asp-page-handler="Delete" type="submit" class="btn btn-danger" value="Delete Selected"/>
-
+    <div class="row ml-2 mr-2">
+        <button asp-page-handler="Delete" type="submit" class="btn btn-danger">Delete Selected <i class="fas fa-trash-alt"></i></button>
+    </div>
     <div class="row ml-2 mr-2 mt-3 mb-3">
         <div class="container border col-12 p-0">
             @if (Model.Expenses.Any())
@@ -115,7 +116,7 @@ else
                     {
                         <tr class="table-light border-primary">
                             <td class="border-primary border entry-table-side">
-                                <input class="bigger" name="chkEntry" type="checkbox" value="@item.Id" />
+                                <input class="bigger" name="chkEntry" type="checkbox" value="@item.Id"/>
                             </td>
                             <td class=" border-right-0 border-primary text-nowrap entry-column">
                                 <div class="row">
@@ -154,7 +155,7 @@ else
                     }
                 </table>
             }
-       
+
         </div>
     </div>
 </form>

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -103,57 +103,59 @@ else
         <div class="container border col-12 p-0">
             @if (Model.Expenses.Any())
             {
-                <table class="table table-hover mb-0">
-                    <tr class="bg-primary">
-                        <th class="border-right entry-table-side" scope="col">
-                            <input class="bigger" type="checkbox" onClick="toggle(this)"/><br/>
-                        </th>
-                        <th colspan="2" scope="col">
-                            <h5 class="text-light">Expenses</h5>
-                        </th>
-                    </tr>
-                    @foreach (var item in Model.Expenses.OrderByDescending(x => x.Date))
-                    {
-                        <tr class="table-light border-primary">
-                            <td class="border-primary border entry-table-side">
-                                <input class="bigger" name="chkEntry" type="checkbox" value="@item.Id"/>
-                            </td>
-                            <td class=" border-right-0 border-primary text-nowrap entry-column">
-                                <div class="row">
-                                    <div class="col-12 mb-2">
-                                        <strong class="text-info">
-                                            @Html.DisplayFor(m => item.Title)
-                                        </strong>
-                                    </div>
-                                    <div class="col-12 col-md-5 col-lg-4">
-                                        <span class="text-info">Amount:</span>
-                                        @NumberFormatter.FormatCurrency(item.Amount)
-                                    </div>
-                                    <div class="col-12 col-md-3 col-lg-2">
-                                        <span class="text-info">Date: </span>
-                                        @item.Date.ToShortDateString()
-                                    </div>
-                                    <div class="col-12 col-md-4">
-                                        <span class="text-info">Importance: </span>
-                                        @((Importance) item.Importance)
-                                    </div>
-                                    <div class="col-12 col-md-4 col-lg-2">
-                                        <span class="text-info">Recurring: </span>
-                                        @if (item.Recurring)
-                                        {
-                                            <i class="fas fa-check text-success"></i>
-                                        }
-                                    </div>
-
-                                </div>
-                            </td>
-                            <td class="border-primary border-left-0 entry-table-side">
-                                <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="2" class="btn btn-sm btn-outline-success"><i class="far fa-edit"></i> </a>
-                                <!--<input asp-page-handler="Delete" asp-route-id="@item.Id" type="submit" class="btn btn-sm btn-outline-danger" value="x" />-->
-                            </td>
+                <div class="table-responsive">
+                    <table class="table table-hover mb-0">
+                        <tr class="bg-primary">
+                            <th class="border-right entry-table-side" scope="col">
+                                <input class="bigger" type="checkbox" onClick="toggle(this)"/><br/>
+                            </th>
+                            <th colspan="2" scope="col">
+                                <h5 class="text-light">Expenses</h5>
+                            </th>
                         </tr>
-                    }
-                </table>
+                        @foreach (var item in Model.Expenses.OrderByDescending(x => x.Date))
+                        {
+                            <tr class="table-light border-primary">
+                                <td class="border-primary border entry-table-side">
+                                    <input class="bigger" name="chkEntry" type="checkbox" value="@item.Id"/>
+                                </td>
+                                <td class=" border-right-0 border-primary text-nowrap entry-column">
+                                    <div class="row">
+                                        <div class="col-12 mb-2">
+                                            <strong class="text-info">
+                                                @Html.DisplayFor(m => item.Title)
+                                            </strong>
+                                        </div>
+                                        <div class="col-12 col-md-5 col-lg-4">
+                                            <span class="text-info">Amount:</span>
+                                            @NumberFormatter.FormatCurrency(item.Amount)
+                                        </div>
+                                        <div class="col-12 col-md-3 col-lg-2">
+                                            <span class="text-info">Date: </span>
+                                            @item.Date.ToShortDateString()
+                                        </div>
+                                        <div class="col-12 col-md-4">
+                                            <span class="text-info">Importance: </span>
+                                            @((Importance) item.Importance)
+                                        </div>
+                                        <div class="col-12 col-md-4 col-lg-2">
+                                            <span class="text-info">Recurring: </span>
+                                            @if (item.Recurring)
+                                            {
+                                                <i class="fas fa-check text-success"></i>
+                                            }
+                                        </div>
+
+                                    </div>
+                                </td>
+                                <td class="border-primary border-left-0 entry-table-side">
+                                    <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="2" class="btn btn-sm btn-outline-success"><i class="far fa-edit"></i> </a>
+                                    <!--<input asp-page-handler="Delete" asp-route-id="@item.Id" type="submit" class="btn btn-sm btn-outline-danger" value="x" />-->
+                                </td>
+                            </tr>
+                        }
+                    </table>
+                </div>
             }
 
         </div>

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -99,29 +99,22 @@ else
 <input asp-page-handler="Delete" type="submit" class="btn btn-danger" value="Delete Selected"/>
 
 <div class="row">
-    <div class="col-12 border mt-3 mb-3">
-       
-            @if (Model.Expenses.Any())
+    <div class="col-12 mt-3 mb-3">
+        @if (Model.Expenses.Any())
             {
-                <table class="table table-hover border-primary table-bordered">
-                    <tr class="table-primary">
-                        <th scope="col">
-
-                        </th>
-                        <th scope="col">
-                            Expenses
-                        </th>
-                        <th scope="col">
-                            Edit
+                <table class="table table-hover border-primary">
+                    <tr class="bg-primary">
+                        <th colspan="3" scope="col">
+                            <h5 class="text-light">Expenses</h5>
                         </th>
                     </tr>
                     @foreach (var item in Model.Expenses.OrderByDescending(x => x.Date))
                     {
                         <tr class="table-light border-primary">
-                            <td class="border-primary entry-table-side">
+                            <td class="border-primary border entry-table-side">
                                 <input name="chkEntry" type="checkbox" value="@item.Id"/>
                             </td>
-                            <td class="border-primary text-nowrap entry-column">
+                            <td class=" border-right-0 border-primary text-nowrap entry-column">
                                 <div class="row">
                                     <div class="col-12 mb-2">
                                         <strong class="text-info">
@@ -150,9 +143,9 @@ else
 
                                 </div>
                             </td>
-                            <td class="border-primary entry-table-side">
-                                <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="2" class="btn btn-sm btn-success">Edit </a>
-                                <input asp-page-handler="Delete" asp-route-id="@item.Id" type="submit" class="btn btn-sm btn-danger" value="Delete" />
+                            <td class="border-left-0 border-primary entry-table-side">
+                                <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="2" class="btn btn-sm btn-outline-success"><i class="far fa-edit"></i> </a>
+                                <!--<input asp-page-handler="Delete" asp-route-id="@item.Id" type="submit" class="btn btn-sm btn-outline-danger" value="x" />-->
                             </td>
                         </tr>
                     }

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -95,11 +95,12 @@ else
 
 }
 
-<button class="btn btn-danger" disabled>Delete Selected</button>
+<form method="post">
+<input asp-page-handler="Delete" type="submit" class="btn btn-danger" value="Delete Selected"/>
 
 <div class="row">
     <div class="col-12 border mt-3 mb-3">
-        <form method="post">
+       
             @if (Model.Expenses.Any())
             {
                 <table class="table table-hover border-primary table-bordered">
@@ -118,7 +119,7 @@ else
                     {
                         <tr class="table-light border-primary">
                             <td class="border-primary entry-table-side">
-                                <input type="checkbox"/>
+                                <input name="chkEntry" type="checkbox" value="@item.Id"/>
                             </td>
                             <td class="border-primary text-nowrap entry-column">
                                 <div class="row">
@@ -157,10 +158,10 @@ else
                     }
                 </table>
             }
-        </form>
+       
     </div>
 </div>
-
+</form>
 <!--
 <div class="row">
     <div class="col-12 border mt-3 mb-3">

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -95,6 +95,8 @@ else
 
 }
 
+<button class="btn btn-danger" disabled>Delete Selected</button>
+
 <div class="row">
     <div class="col-12 border mt-3 mb-3">
         <form method="post">

--- a/src/Pages/Expenses.cshtml.cs
+++ b/src/Pages/Expenses.cshtml.cs
@@ -22,7 +22,7 @@ namespace ePiggyWeb.Pages
 
         [Required(ErrorMessage = "Title Required.")]
         [BindProperty]
-        [StringLength(30)]
+        [StringLength(25, ErrorMessage = "Too long title!")]
         public string Title { get; set; }
         [Required(ErrorMessage = "Amount Required.")]
         [BindProperty]

--- a/src/Pages/Expenses.cshtml.cs
+++ b/src/Pages/Expenses.cshtml.cs
@@ -20,18 +20,18 @@ namespace ePiggyWeb.Pages
         public bool WasException { get; set; }
         public IEntryList Expenses { get; set; }
 
-        [Required(ErrorMessage = "Required")]
+        [Required(ErrorMessage = "Title Required.")]
         [BindProperty]
         [StringLength(30)]
         public string Title { get; set; }
-        [Required(ErrorMessage = "Required")]
+        [Required(ErrorMessage = "Amount Required.")]
         [BindProperty]
-        [Range(0, 99999999.99)]
+        [Range(0, 99999999.99, ErrorMessage = "Amount out of range!")]
         public decimal Amount { get; set; }
         [BindProperty]
         public DateTime Date { get; set; }
         [BindProperty]
-        [Required(ErrorMessage = "Required")]
+        [Required(ErrorMessage = "Importance Required.")]
         public int Importance { get; set; }
         [BindProperty]
         public bool Recurring { get; set; }

--- a/src/Pages/Expenses.cshtml.cs
+++ b/src/Pages/Expenses.cshtml.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using ePiggyWeb.DataBase;
@@ -115,16 +117,33 @@ namespace ePiggyWeb.Pages
         {
             try
             {
+                var selected = Request.Form["chkEntry"].ToString();
+                var selectedList = selected.Split(',');
+                var entryIdList = selectedList.Select(temp => Convert.ToInt32(temp)).ToList();
+
                 UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
-                await EntryDatabase.DeleteAsync(id, UserId, EntryType.Expense);
+
+                await EntryDatabase.DeleteListAsync(entryIdList, UserId, EntryType.Expense);
             }
             catch (Exception ex)
             {
                 _logger.LogInformation(ex.ToString());
                 WasException = true;
             }
-            
-            return RedirectToPage("/expenses");
+           
+
+                /* try
+                 {
+                     UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
+                     await EntryDatabase.DeleteAsync(id, UserId, EntryType.Expense);
+                 }
+                 catch (Exception ex)
+                 {
+                     _logger.LogInformation(ex.ToString());
+                     WasException = true;
+                 }*/
+
+                return RedirectToPage("/expenses");
         }
 
         private async Task SetData()

--- a/src/Pages/ExpensesGraph.cshtml
+++ b/src/Pages/ExpensesGraph.cshtml
@@ -14,11 +14,13 @@ else
 {
     <form method="get" class="mt-5">
         <input type="hidden" name="handler" value="Filter" />
-        <label class="text-light">Period:</label>
-        <input for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
-        <label class="text-light"> - </label>
-        <input for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
-        <input type="submit" value="Filter" class="btn btn-warning ml-5" />
+        <label class="text-light col-md-4">Period:</label>
+        <div class="row justify-content-center">
+            <input class="col-md-3 col-sm-5 col-5" for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
+            <label class="text-light ml-2 mr-2"> - </label>
+            <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
+        </div>
+        <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
 }

--- a/src/Pages/ExpensesGraph.cshtml
+++ b/src/Pages/ExpensesGraph.cshtml
@@ -20,7 +20,7 @@ else
             <label class="text-light ml-2 mr-2"> - </label>
             <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
         </div>
-        <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
+        <button type="submit" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3">Filter<i class="fas fa-filter"></i></button>
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
 }

--- a/src/Pages/Goals.cshtml
+++ b/src/Pages/Goals.cshtml
@@ -125,12 +125,12 @@ else
                     <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                     <div class="form-group">
                         <input asp-for="Title" type="text" placeholder="Title*" value="" />
-                        <span asp-validation-for="Title" class="text-danger"></span>
                     </div>
+                    <div class="form-group"><span asp-validation-for="Title" class="text-danger"></span></div>
                     <div class="form-group">
                         <input asp-for="Amount" type="text" placeholder="Amount*" value="" />
-                        <span asp-validation-for="Amount" class="text-danger"></span>
                     </div>
+                    <div class="form-group"><span asp-validation-for="Amount" class="text-danger"></span></div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/src/Pages/Goals.cshtml
+++ b/src/Pages/Goals.cshtml
@@ -14,8 +14,8 @@ else
 {
     <br />
     <h2 class="text-info">Goals</h2>
-    <button type="button" class="btn btn-primary text-light mt-3" data-toggle="modal" data-target="#AddGoalModal">Add Goal</button>
-    <button type="button" class="btn btn-outline-light mt-3" data-toggle="modal" data-target="#ParseGoalModal">Parse Goal</button>
+    <button type="button" class="btn btn-primary text-light mt-3" data-toggle="modal" data-target="#AddGoalModal">Add Goal<i class="ml-1 fas fa-pencil-alt"></i></button>
+    <button type="button" class="btn btn-outline-light mt-3" data-toggle="modal" data-target="#ParseGoalModal">Parse Goal<i class="ml-1 fas fa-cloud-download-alt"></i></button>
 }
 
 @if (!ModelState.IsValid)

--- a/src/Pages/Income.cshtml
+++ b/src/Pages/Income.cshtml
@@ -97,7 +97,7 @@ else
 }
 
 <div class="row">
-    <div class="col-10 border mt-3 mb-3">
+    <div class="col-12 border mt-3 mb-3">
         <form method="post">
             @if (Model.Income.Any())
             {
@@ -156,9 +156,6 @@ else
                 <p>No income available</p>
             }
         </form>
-    </div>
-    <div class="col-2 border p-3 mt-3 mb-3">
-        
     </div>
 </div>
 

--- a/src/Pages/Income.cshtml
+++ b/src/Pages/Income.cshtml
@@ -29,7 +29,7 @@ else
             </div>
         </div>
     }
-  
+
     <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#addEntryCollapse" aria-expanded="false" aria-controls="collapseExample">
         Add Income
     </button>
@@ -96,6 +96,37 @@ else
     <hr class="mt-4 mb-4" />
 }
 
+<button class="btn btn-danger mb-4" disabled>Delete Selected</button>
+<div class="row justify-content-center">
+    <form method="post">
+        <div class="row justify-content-center">
+            @foreach (var item in Model.Income.OrderByDescending(x => x.Date))
+            {
+                <div class="card border-light mb-3 col-12 col-md-5 col-lg-3 bg-primary" style="max-width: 20rem; min-width: 20rem">
+                    <div class="card-header entry-table-side">
+                        <div class="row justify-content-between">
+                            <input class="col-2 mt-2" type="checkbox" />
+                            <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="1" class="btn btn-sm btn-warning col-3">Edit </a>
+                        </div>
+                    </div>
+                    <div class="card-body text-light entry-column">
+                        <h5 class="card-title">@Html.DisplayFor(m => item.Title)</h5>
+                        Amount:  @NumberFormatter.FormatCurrency(item.Amount) <br />
+                        Importance: @((Importance)item.Importance) <br />
+                        Recurring: @if (item.Recurring)
+                        {
+                            <i class="fas fa-check text-success"></i>
+                        }
+                    </div>
+                    <div class="card-footer text-light">@item.Date.ToShortDateString()</div>
+                </div>
+            }
+        </div>
+    </form>
+</div>
+
+<!--
+
 <div class="row">
     <div class="col-12 border mt-3 mb-3">
         <form method="post">
@@ -159,3 +190,4 @@ else
     </div>
 </div>
 
+-->

--- a/src/Pages/Income.cshtml
+++ b/src/Pages/Income.cshtml
@@ -31,7 +31,7 @@ else
     }
 
     <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#addEntryCollapse" aria-expanded="false" aria-controls="collapseExample">
-        Add Income
+        Add Income<i class="ml-1 fas fa-pencil-alt"></i>
     </button>
     <div class="collapse mt-3" id="addEntryCollapse">
         <form method="post" asp-page-handler="NewEntry">
@@ -87,7 +87,7 @@ else
             <label class="text-light ml-2 mr-2"> - </label>
             <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
         </div>
-        <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
+        <button type="submit" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3">Filter<i class="fas fa-filter"></i></button>
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
     <hr class="mt-4 mb-4" />

--- a/src/Pages/Income.cshtml
+++ b/src/Pages/Income.cshtml
@@ -16,44 +16,9 @@ else
     <div class="container p-0 mt-3">
         <h2 class="text-info">Income</h2>
     </div>
+    <hr class="mt-4 mb-4" />
 
-    <form method="post" asp-page-handler="NewEntry">
-        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-        <input asp-for="Title" type="text" placeholder="Title" value="" />
-        <span asp-validation-for="Title" class="text-danger"></span>
-        <input asp-for="Amount" type="text" placeholder="Amount" value="" />
-        <span asp-validation-for="Amount" class="text-danger"></span>
-        <input asp-for="Date" type="date" value="@DateTime.Now.ToShortDateString()" />
-        <!-- <label class="text-light ml-3">Importance</label>-->
-        <select asp-for="Importance" class="ml-3">
-            <option hidden disabled selected value="">Importance</option>
-            <option value="1">Necessary</option>
-            <option value="2">High</option>
-            <option value="3">Medium</option>
-            <option value="4">Low</option>
-            <option value="5">Unnecessary</option>
-        </select>
-        <span asp-validation-for="Importance" class="text-danger"></span>
-        <label class="text-light ml-3">Is Monthly?</label>
-        <input asp-for="Recurring" type="checkbox" placeholder="" />
-        <input type="submit" value="Add" class="btn btn-primary ml-5" />
-        <input class="btn btn-danger ml-2" type="reset" value="Reset">
-    </form>
-
-    <form method="get" class="mt-5">
-        <input type="hidden" name="handler" value="Filter" />
-        <label class="text-light col-md-4">Period:</label>
-        <div class="row justify-content-center">
-            <input class="col-md-3 col-sm-5 col-5" for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
-            <label class="text-light ml-2 mr-2"> - </label>
-            <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
-        </div>
-        <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
-        <p class="text-warning">@Model.ErrorMessage</p>
-    </form>
-}
-
-@if (!ModelState.IsValid)
+    @if (!ModelState.IsValid)
     {
         <div class="container">
             <div class="alert alert-danger alert-dismissible fade show mt-2" role="alert">
@@ -64,32 +29,98 @@ else
             </div>
         </div>
     }
+  
+    <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#addEntryCollapse" aria-expanded="false" aria-controls="collapseExample">
+        Add Income
+    </button>
+    <div class="collapse mt-3" id="addEntryCollapse">
+        <form method="post" asp-page-handler="NewEntry">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="container">
+                <div class="row justify-content-center p-0">
+                    <div class="col-12 col-md-4 col-lg-3 mb-1">
+                        <input asp-for="Title" type="text" placeholder="Title" value="" />
+                    </div>
+                    <div class="col-12 col-md-4 col-lg-3 mb-1">
+                        <input asp-for="Amount" type="text" placeholder="Amount" value="" />
+                    </div>
+                    <div class="col-12 col-md-4 col-lg-3 mb-1">
+                        <input asp-for="Date" type="date" value="@DateTime.Now.ToShortDateString()" />
+                    </div>
+                </div>
+                <div class="row justify-content-center mb-3">
+                    <div class="col-12 col-md-3 col-lg-2">
+                        <select asp-for="Importance">
+                            <option hidden disabled selected value="">Importance</option>
+                            <option value="1">Necessary</option>
+                            <option value="2">High</option>
+                            <option value="3">Medium</option>
+                            <option value="4">Low</option>
+                            <option value="5">Unnecessary</option>
+                        </select>
+                    </div>
+                    <div class="col-12 col-md-3 col-lg-2">
+                        <label class="text-light">Is Monthly?</label>
+                        <input asp-for="Recurring" type="checkbox" placeholder="" />
+                    </div>
+                </div>
+                <div class="container col-12 col-md-4 col-lg-3">
+                    <input type="submit" value="Add" class="btn btn-primary" />
+                    <input class="btn btn-danger" type="reset" value="Reset">
+                </div>
+            </div>
+        </form>
+    </div>
+    <div class="container mt-3">
+        <span asp-validation-for="Title" class="text-danger"></span>
+        <span asp-validation-for="Amount" class="text-danger"></span>
+        <span asp-validation-for="Importance" class="text-danger"></span>
+    </div>
 
-    <div class="row">
-        <div class="col-10 border mt-3 mb-3">
-            <form method="post">
-                @if (Model.Income.Any())
-                {
-                    <table class="table table-hover border-primary table-bordered">
-                        <tr class="table-primary">
-                            <th>
-                                <label asp-for="Income.FirstOrDefault().Title"></label>
-                            </th>
-                            <th style="width: 18%">
-                                <label asp-for="Income.FirstOrDefault().Amount"></label>
-                            </th>
-                            <th style="width: 10%">
-                                <label asp-for="Income.FirstOrDefault().Date"></label>
-                            </th>
-                            <th style="width: 15%">
-                                <label asp-for="Income.FirstOrDefault().Importance"></label>
-                            </th>
-                            <th style="width: 5%">
-                                <label asp-for="Income.FirstOrDefault().Recurring"></label>
-                            </th>
-                            <th style="width: 15%">
 
-                            </th>
+    <hr class="mt-4 mb-4" />
+    <form method="get">
+        <input type="hidden" name="handler" value="Filter" />
+        <label class="text-light col-md-4">Period:</label>
+        <div class="row justify-content-center">
+            <input class="col-md-3 col-sm-5 col-5" for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
+            <label class="text-light ml-2 mr-2"> - </label>
+            <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
+        </div>
+        <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
+        <p class="text-warning">@Model.ErrorMessage</p>
+    </form>
+    <hr class="mt-4 mb-4" />
+    <h5 class="text-light">Earned this period: @NumberFormatter.FormatCurrency(Model.Income.GetSum())</h5>
+    <h5 class="text-light">All income: @NumberFormatter.FormatCurrency(Model.AllIncome)</h5>
+    <hr class="mt-4 mb-4" />
+}
+
+<div class="row">
+    <div class="col-10 border mt-3 mb-3">
+        <form method="post">
+            @if (Model.Income.Any())
+            {
+                <table class="table table-hover border-primary table-bordered">
+                    <tr class="table-primary">
+                        <th>
+                            <label asp-for="Income.FirstOrDefault().Title"></label>
+                        </th>
+                        <th style="width: 18%">
+                            <label asp-for="Income.FirstOrDefault().Amount"></label>
+                        </th>
+                        <th style="width: 10%">
+                            <label asp-for="Income.FirstOrDefault().Date"></label>
+                        </th>
+                        <th style="width: 15%">
+                            <label asp-for="Income.FirstOrDefault().Importance"></label>
+                        </th>
+                        <th style="width: 5%">
+                            <label asp-for="Income.FirstOrDefault().Recurring"></label>
+                        </th>
+                        <th style="width: 15%">
+
+                        </th>
                     </tr>
                     @foreach (var item in Model.Income.OrderByDescending(x => x.Date))
                     {
@@ -116,19 +147,18 @@ else
                                 <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="1" class="btn btn-sm btn-success">Edit </a>
                                 <input asp-page-handler="Delete" asp-route-id="@item.Id" type="submit" class="btn btn-sm btn-danger" value="Delete" />
                             </td>
-                            </tr>
-                        }
-                    </table>
-                }
-                else
-                {
-                    <p>No income available</p>
-                }
+                        </tr>
+                    }
+                </table>
+            }
+            else
+            {
+                <p>No income available</p>
+            }
         </form>
     </div>
     <div class="col-2 border p-3 mt-3 mb-3">
-        <p class="text-light">Earned this period: @NumberFormatter.FormatCurrency(Model.Income.GetSum())</p>
-        <p class="text-light">All income: @NumberFormatter.FormatCurrency(Model.AllIncome)</p>
+        
     </div>
-    </div>
+</div>
 

--- a/src/Pages/Income.cshtml
+++ b/src/Pages/Income.cshtml
@@ -42,11 +42,13 @@ else
 
     <form method="get" class="mt-5">
         <input type="hidden" name="handler" value="Filter" />
-        <label class="text-light">Period:</label>
-        <input for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
-        <label class="text-light"> - </label>
-        <input for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
-        <input type="submit" value="Filter" class="btn btn-warning ml-5" />
+        <label class="text-light col-md-4">Period:</label>
+        <div class="row justify-content-center">
+            <input class="col-md-3 col-sm-5 col-5" for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
+            <label class="text-light ml-2 mr-2"> - </label>
+            <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
+        </div>
+        <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
 }

--- a/src/Pages/Income.cshtml.cs
+++ b/src/Pages/Income.cshtml.cs
@@ -21,18 +21,18 @@ namespace ePiggyWeb.Pages
         public bool WasException { get; set; }
         public IEntryList Income { get; set; }
 
-        [Required(ErrorMessage = "Required")]
+        [Required(ErrorMessage = "Title Required.")]
         [BindProperty]
         [StringLength(30)]
         public string Title { get; set; }
-        [Required(ErrorMessage = "Required")]
+        [Required(ErrorMessage = "Amount Required.")]
         [BindProperty]
-        [Range(0, 99999999.99)]
+        [Range(0, 99999999.99, ErrorMessage = "Amount out of range!")]
         public decimal Amount { get; set; }
         [BindProperty]
         public DateTime Date { get; set; }
         [BindProperty]
-        [Required(ErrorMessage = "Required")]
+        [Required(ErrorMessage = "Importance Required.")]
         public int Importance { get; set; }
         [BindProperty]
         public bool Recurring { get; set; }

--- a/src/Pages/IncomeGraph.cshtml
+++ b/src/Pages/IncomeGraph.cshtml
@@ -13,13 +13,15 @@
 else
 {
     <form method="get" class="mt-5">
-        <input type="hidden" name="handler" value="Filter" />
-        <label class="text-light">Period:</label>
-        <input for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
-        <label class="text-light"> - </label>
-        <input for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
-        <input type="submit" value="Filter" class="btn btn-warning ml-5" />
-        <p class="text-warning">@Model.ErrorMessage</p>
+    <input type="hidden" name="handler" value="Filter" />
+            <label class="text-light col-md-4">Period:</label>
+            <div class="row justify-content-center">
+                <input class="col-md-3 col-sm-5 col-5" for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
+                <label class="text-light ml-2 mr-2"> - </label>
+                <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
+            </div>
+            <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
+            <p class="text-warning">@Model.ErrorMessage</p>
     </form>
 }
 

--- a/src/Pages/IncomeGraph.cshtml
+++ b/src/Pages/IncomeGraph.cshtml
@@ -13,15 +13,14 @@
 else
 {
     <form method="get" class="mt-5">
-    <input type="hidden" name="handler" value="Filter" />
-            <label class="text-light col-md-4">Period:</label>
-            <div class="row justify-content-center">
-                <input class="col-md-3 col-sm-5 col-5" for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
-                <label class="text-light ml-2 mr-2"> - </label>
-                <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
-            </div>
-            <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
-            <p class="text-warning">@Model.ErrorMessage</p>
+        <input type="hidden" name="handler" value="Filter" />
+        <label class="text-light col-md-4">Period:</label>
+        <div class="row justify-content-center">
+            <input class="col-md-3 col-sm-5 col-5" for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
+            <label class="text-light ml-2 mr-2"> - </label>
+            <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" /></div>
+        <button type="submit" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3">Filter<i class="fas fa-filter"></i></button>
+        <p class="text-warning">@Model.ErrorMessage</p>
     </form>
 }
 

--- a/src/Pages/Index.cshtml
+++ b/src/Pages/Index.cshtml
@@ -15,7 +15,7 @@
    
 }
 
-<div class="container index-Top">
+<div class="container index-Top mb-4">
     <div class="container col-md-6 col-lg-4">
         <img src="images/mainLogo.PNG" class="title-image mt-2" alt="mainLogo">
     </div>
@@ -25,7 +25,9 @@
         <p class="lead">Hope You are having good time saving!</p>
         <hr class="my-4">
         <p class="lead">
-            <a class="btn btn-primary btn-lg" asp-page="/Goals" role="button">Your Goals</a>
+            <a class="btn btn-primary mt-2" asp-page="/expenses" role="button"><i class="fas fa-hand-holding-usd"></i>Expenses</a>
+            <a class="btn btn-primary mt-2" asp-page="/income" role="button"><i class="fas fa-coins"></i>Income</a>
+            <a class="btn btn-primary mt-2" asp-page="/goals" role="button"><i class="fas fa-bullseye"></i> Goals </a>
         </p>
     }
     else

--- a/src/Pages/Index.cshtml
+++ b/src/Pages/Index.cshtml
@@ -16,7 +16,9 @@
 }
 
 <div class="container index-Top">
-    <img src="images/mainLogo.PNG" class="title-image mt-2">
+    <div class="container col-md-6 col-lg-4">
+        <img src="images/mainLogo.PNG" class="title-image mt-2" alt="mainLogo">
+    </div>
     @if (User.Identity.IsAuthenticated)
     {
         <h1 class="display-4">Welcome Back!</h1>

--- a/src/Pages/Login.cshtml
+++ b/src/Pages/Login.cshtml
@@ -12,7 +12,7 @@
         </div>
     </div>
 }
-<div class="container login-container">
+<div class="container login-container col-lg-6 col-md-8 col-sm-10 col-12">
     <div class="login-form-2">
         <h3>Sign In</h3>
         <form method="post">

--- a/src/Pages/Login.cshtml
+++ b/src/Pages/Login.cshtml
@@ -12,7 +12,7 @@
         </div>
     </div>
 }
-<div class="container login-container col-lg-6 col-md-8 col-sm-10 col-12">
+<div class="container login-container col-lg-4 col-md-8 col-sm-10 col-12">
     <div class="login-form-2">
         <h3>Sign In</h3>
         <form method="post">

--- a/src/Pages/Login.cshtml
+++ b/src/Pages/Login.cshtml
@@ -13,7 +13,7 @@
     </div>
 }
 <div class="container login-container col-lg-4 col-md-8 col-sm-10 col-12">
-    <div class="login-form-2">
+    <div class="login-form-2 bg-primary">
         <h3>Sign In</h3>
         <form method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>

--- a/src/Pages/MonthlyReport.cshtml
+++ b/src/Pages/MonthlyReport.cshtml
@@ -1,0 +1,97 @@
+﻿@page
+@using System.Globalization
+@using ePiggyWeb.Utilities
+@model ePiggyWeb.Pages.MonthlyReportModel
+
+@if (Model.WasException)
+{
+    <div class="alert alert-danger" role="alert">
+        Whoops! Something went wrong!
+    </div>
+    <h1 class="text-warning">Example Goals data used:</h1>
+}
+<div data-aos="slide-down">
+
+    <h2 class="text-light mt-5 mb-3">Report</h2>
+    <h5 class="text-light">@Model.Data.Start.ToShortDateString() - @Model.Data.End.ToShortDateString()</h5>
+    <hr class="mt-5 mb-5"/>
+</div>
+<div data-aos="fade-up">
+    <h4 class="text-light">Income of period: </h4>
+    <h3 class="text-light mt-2 mb-2">@NumberFormatter.FormatCurrency(Model.Data.Income)</h3>
+    <h4 class="text-light">Expenses of period: </h4>
+    <h3 class="text-light mt-2 mb-2">@NumberFormatter.FormatCurrency(Model.Data.Expenses)</h3>
+
+    <div class="container p-0 mt-3 mb-5">
+        <div class="col-lg-12" id="graph">
+            <div class="spinner-border text-warning loader" role="status">
+                <span class="sr-only">Loading...</span>
+            </div>
+        </div>
+    </div>
+</div>
+<hr class="mt-5 mb-5" />
+
+<div data-aos="fade-up">
+    @if (Model.Data.NecessarySum > Model.Data.BiggestCategorySum)
+    {
+        <h3 class="text-light">Well done, you've spend most money for the necessary expenses!<i class="ml-1 fas fa-award fa-4x"></i></h3>
+        <h5 class="text-light">@NumberFormatter.FormatCurrency(Model.Data.NecessarySum)</h5>
+    }
+    else
+    {
+        <h5 class="text-light">Biggest Expenses Category: </h5>
+        <h4 class="text-light">@Model.Data.BiggestCategory</h4>
+        <h5 class="text-light">It was bigger than Necessary expenses by:</h5>
+        <h4 class="text-light">@Model.Data.HowMuchBigger.ToString("#.##")%</h4>
+        <br />
+        <h5 class="text-light">Necessary expenses sum: </h5>
+        <h5 class="text-light">@NumberFormatter.FormatCurrency(Model.Data.NecessarySum)</h5>
+        <h5 class="text-light">@Model.Data.BiggestCategory expenses sum:</h5>
+        <h5 class="text-light">@NumberFormatter.FormatCurrency(Model.Data.BiggestCategorySum)</h5>
+
+    }
+</div>
+<hr class="mt-5 mb-5" />
+
+<script src="https://unpkg.com/aos@next/dist/aos.js"></script>
+<script>
+    AOS.init();
+</script>
+<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+<script>
+    $(window).resize(function () {
+        drawChart();
+    });
+</script>
+<script type="text/javascript">
+    // Load google charts
+    google.charts.load('current', { 'packages': ['corechart'] });
+    google.charts.setOnLoadCallback(drawChart);
+
+    // Draw the chart and set the chart values
+    function drawChart() {
+        var data = google.visualization.arrayToDataTable([
+            ['Type', 'Amount'],
+            ['Expenses', @Model.Data.Expenses.ToString(CultureInfo.InvariantCulture)],
+            ['Income',  @Model.Data.Income.ToString(CultureInfo.InvariantCulture)]
+        ]);
+
+        // Optional; add a title and set the width and height of the chart
+        var options = {
+            'title': 'Income/expenses comparison',
+            'height': 250,
+            'width': '50%',
+            'vAxis': { 'textStyle': { 'color': '#FFF' }},
+            'backgroundColor': { 'fill': 'transparent' },
+            'colors': ['#F44336', '#3F51B5'],
+            'legend': { 'position': 'top', 'maxLines': 2 },
+            'legendTextStyle': { color: '#FFF' },
+            'titleTextStyle': { color: '#FFF', bold: 'true', fontSize: 16 },
+            'hAxis': { 'textStyle': { 'color': '#FFF' } }
+        };
+
+        var chart = new google.visualization.PieChart(document.getElementById('graph'));
+        chart.draw(data, options);
+    }
+</script>

--- a/src/Pages/MonthlyReport.cshtml
+++ b/src/Pages/MonthlyReport.cshtml
@@ -53,7 +53,7 @@
     <h3 class="text-light mt-3 mb-3"><span class="text-info"><i class="mr-1 fas fa-money-bill-wave"></i></span>Your expenses:</h3>
     @if (Model.Data.NecessarySum > Model.Data.BiggestCategorySum)
     {
-        <h4 class="text-light"><span class="text-warning"><i class="mr-1 fas fa-award"></i></span>Well done, you've spend most money for the necessary expenses!</h4>
+        <h4 class="text-light"><span class="text-warning"><i class="mr-1 fas fa-award"></i></span>Well done, you've spent most money for the necessary expenses!</h4>
         <h5 class="text-light">@NumberFormatter.FormatCurrency(Model.Data.NecessarySum)</h5>
     }
     else

--- a/src/Pages/MonthlyReport.cshtml
+++ b/src/Pages/MonthlyReport.cshtml
@@ -141,8 +141,15 @@
             </div>
         </div>
     </div>
+    <hr class="mt-5 mb-5" />
 }
-<hr class="mt-5 mb-5" />
+else
+{
+    <!--<div data-aos="fade-up">
+        <h5 class="mb-3 text-light"><span class="text-warning"><i class="fas fa-exclamation-triangle"></i></span>Goal data unavailable since you have less than 2 goals or your budget is negative... </h5>
+        <a class="btn btn-primary" href="/goals"><i class="mr-1 fas fa-bullseye"></i>To Goals</a>
+    </div>-->
+}
 <div data-aos="fade-up">
     <button class="btn btn-primary mb-4" disabled>Save as an E-Mail<i class="ml-1 far fa-envelope"></i></button>
 </div>

--- a/src/Pages/MonthlyReport.cshtml
+++ b/src/Pages/MonthlyReport.cshtml
@@ -62,7 +62,7 @@
         <h4 class="text-warning">@Model.Data.BiggestCategory</h4>
         <h5 class="text-light">It was bigger than Necessary expenses by:</h5>
         <h4 class="text-warning">@Model.Data.HowMuchBigger.ToString("#.##")%</h4>
-        <br/>
+        <br />
         <h5 class="text-light">Necessary expenses sum: </h5>
         <h5 class="text-light">@NumberFormatter.FormatCurrency(Model.Data.NecessarySum)</h5>
         <h5 class="text-light">@Model.Data.BiggestCategory expenses sum:</h5>
@@ -98,15 +98,16 @@
     <div data-aos="fade-up">
         <a class="btn btn-primary" href="/goals"><i class="mr-1 fas fa-bullseye"></i>To Goals</a>
     </div>
+    <hr class="mt-5 mb-5" />
 }
 
-<hr class="mt-5 mb-5" />
+
 @if (Model.Data.HasGoals)
 {
     <div data-aos="fade-up">
         @if (Model.Data.MonthsForCheapestGoal <= 12)
         {
-            <h4><span class="text-warning"><i class="mr-1 fas fa-trophy"></i></span>If you keep it up you'll save up for your goals:</h4>
+            <h4 class="mb-3 text-light"><span class="text-warning"><i class="mr-1 fas fa-trophy"></i></span>If you keep it up you'll save up for your goals:</h4>
         }
         else
         {

--- a/src/Pages/MonthlyReport.cshtml
+++ b/src/Pages/MonthlyReport.cshtml
@@ -51,7 +51,11 @@
 
 <div data-aos="fade-up">
     <h3 class="text-light mt-3 mb-3"><span class="text-info"><i class="mr-1 fas fa-money-bill-wave"></i></span>Your expenses:</h3>
-    @if (Model.Data.NecessarySum > Model.Data.BiggestCategorySum)
+    @if (Model.Data.BiggestCategorySum == 0)
+    {
+        <h4 class="text-light"><span class="text-success"><i class="fas fa-dollar-sign"></i></span>You did not have any expenses...</h4>
+        <a class="btn btn-primary mt-2" asp-page="/expenses" role="button"><i class="fas fa-hand-holding-usd"></i>To Expenses</a>
+    }else if (Model.Data.NecessarySum >= Model.Data.BiggestCategorySum)
     {
         <h4 class="text-light"><span class="text-warning"><i class="mr-1 fas fa-award"></i></span>Well done, you've spent most money for the necessary expenses!</h4>
         <h5 class="text-light">@NumberFormatter.FormatCurrency(Model.Data.NecessarySum)</h5>
@@ -60,9 +64,18 @@
     {
         <h5 class="text-light">Biggest Expenses Category: </h5>
         <h4 class="text-warning">@Model.Data.BiggestCategory</h4>
-        <h5 class="text-light">It was bigger than Necessary expenses by:</h5>
-        <h4 class="text-warning">@Model.Data.HowMuchBigger.ToString("#.##")%</h4>
-        <br />
+        @if (Model.Data.HowMuchBigger != -1)
+        {
+            <h5 class="text-light">It was bigger than Necessary expenses by:</h5>
+            <h4 class="text-warning">@Model.Data.HowMuchBigger.ToString("#.##")%</h4>
+            <br />
+        }
+        else
+        {
+            <h5 class="text-light">You did not have necessary expenses...</h5>
+            <h4 class="text-warning">Time to plan your expenses?</h4>
+        }
+
         <h5 class="text-light">Necessary expenses sum: </h5>
         <h5 class="text-light">@NumberFormatter.FormatCurrency(Model.Data.NecessarySum)</h5>
         <h5 class="text-light">@Model.Data.BiggestCategory expenses sum:</h5>

--- a/src/Pages/MonthlyReport.cshtml
+++ b/src/Pages/MonthlyReport.cshtml
@@ -14,7 +14,7 @@
 
     <h2 class="text-light mt-5 mb-3">Report</h2>
     <h5 class="text-light">@Model.Data.Start.ToShortDateString() - @Model.Data.End.ToShortDateString()</h5>
-    <hr class="mt-5 mb-5"/>
+    <hr class="mt-5 mb-5" />
 </div>
 <div data-aos="fade-up">
     <h4 class="text-light">Income of period: </h4>
@@ -31,20 +31,38 @@
     </div>
 </div>
 <hr class="mt-5 mb-5" />
+<div data-aos="fade-right">
+    @if (Model.Data.Balance > 0)
+    {
+        <h4 class="text-light"><span class="text-warning"><i class="mr-1 fas fa-piggy-bank"></i></span>You've saved this month:</h4>
+        <h3 class="text-light">@NumberFormatter.FormatCurrency(Model.Data.Balance)</h3>
+    }
+    else if (Model.Data.Balance < 0)
+    {
+        <h4 class="text-light"><span class="text-danger"><i class="mr-1 fas fa-minus-circle"></i></span>Your balance was negative this month:</h4>
+        <h3 class="text-warning">@NumberFormatter.FormatCurrency(Model.Data.Balance)</h3>
+    }
+    else
+    {
+        <h4 class="text-light"><span class="text-danger"><i class="mr-1 fas fa-minus-circle"></i></span>You've spent all you've earned this month</h4>
+    }
+</div>
+<hr class="mt-5 mb-5" />
 
 <div data-aos="fade-up">
+    <h3 class="text-light mt-3 mb-3"><span class="text-info"><i class="mr-1 fas fa-money-bill-wave"></i></span>Your expenses:</h3>
     @if (Model.Data.NecessarySum > Model.Data.BiggestCategorySum)
     {
-        <h3 class="text-light">Well done, you've spend most money for the necessary expenses!<i class="ml-1 fas fa-award fa-4x"></i></h3>
+        <h4 class="text-light"><span class="text-warning"><i class="mr-1 fas fa-award"></i></span>Well done, you've spend most money for the necessary expenses!</h4>
         <h5 class="text-light">@NumberFormatter.FormatCurrency(Model.Data.NecessarySum)</h5>
     }
     else
     {
         <h5 class="text-light">Biggest Expenses Category: </h5>
-        <h4 class="text-light">@Model.Data.BiggestCategory</h4>
+        <h4 class="text-warning">@Model.Data.BiggestCategory</h4>
         <h5 class="text-light">It was bigger than Necessary expenses by:</h5>
-        <h4 class="text-light">@Model.Data.HowMuchBigger.ToString("#.##")%</h4>
-        <br />
+        <h4 class="text-warning">@Model.Data.HowMuchBigger.ToString("#.##")%</h4>
+        <br/>
         <h5 class="text-light">Necessary expenses sum: </h5>
         <h5 class="text-light">@NumberFormatter.FormatCurrency(Model.Data.NecessarySum)</h5>
         <h5 class="text-light">@Model.Data.BiggestCategory expenses sum:</h5>
@@ -52,8 +70,81 @@
 
     }
 </div>
+
 <hr class="mt-5 mb-5" />
 
+@if (Model.Data.SavedUpGoals.Any())
+{
+    <div data-aos="fade-up">
+        <h4 class="text-light"><span class="text-success"><i class=" mr-1 mb-3 fas fa-check-circle"></i></span>Goals You've already saved up for: </h4>
+    </div>
+    <div class="row ml-3 mr-3 justify-content-center">
+        @foreach (var item in Model.Data.SavedUpGoals)
+        {
+            <div data-aos="fade-right" class="card text-center col-lg-4 col-md-6 text-light bg-primary mb-3">
+                <div class="card-header">
+                </div>
+                <div class="card-body">
+                    <h5 class="card-title" title="Title">@item.Title</h5>
+                    <div class="progress-bar bg-success" role="progressbar" style="width: 100%;" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" title="Progress">100%</div>
+                    <p class=" mt-2 card-text" title="Price">Price: @NumberFormatter.FormatCurrency(item.Amount)</p>
+                </div>
+                <div class="card-footer">
+
+                </div>
+            </div>
+        }
+    </div>
+    <div data-aos="fade-up">
+        <a class="btn btn-primary" href="/goals"><i class="mr-1 fas fa-bullseye"></i>To Goals</a>
+    </div>
+}
+
+<hr class="mt-5 mb-5" />
+@if (Model.Data.HasGoals)
+{
+    <div data-aos="fade-up">
+        @if (Model.Data.MonthsForCheapestGoal <= 12)
+        {
+            <h4><span class="text-warning"><i class="mr-1 fas fa-trophy"></i></span>If you keep it up you'll save up for your goals:</h4>
+        }
+        else
+        {
+            <h4 class="mb-3 text-light"><span class="text-success"><i class="mr-1 fas fa-seedling"></i></span>You'll need review your plan in order to save: </h4>
+            <a asp-page="/savingsuggestions" asp-route-id="@Model.Data.CheapestGoal.Id" class="mb-3 btn btn-primary">Suggestions <i class="ml-1 far fa-list-alt"></i></a>
+        }
+    </div>
+    <div class="row ml-3 mr-3 justify-content-center">
+        <div data-aos="fade-right" class="card text-center col-lg-4 col-md-6 text-light bg-primary mb-3">
+            <div class="card-header">
+                <h5 class="text-light">In @Model.Data.MonthsForCheapestGoal month(s)</h5>
+            </div>
+            <div class="card-body">
+                <h5 class="card-title" title="Title">@Model.Data.CheapestGoal.Title month(s)</h5>
+                <h5 class="mt-2 card-text" title="Price">Price: @NumberFormatter.FormatCurrency(@Model.Data.CheapestGoal.Amount)</h5>
+            </div>
+            <div class="card-footer">
+
+            </div>
+        </div>
+        <div data-aos="fade-right" class="card text-center col-lg-4 col-md-6 text-light bg-primary mb-3">
+            <div class="card-header">
+                <h5 class="text-light">In @Model.Data.MonthsForMostExpensiveGoal month(s)</h5>
+            </div>
+            <div class="card-body">
+                <h5 class="card-title" title="Title">@Model.Data.MostExpensiveGoal.Title</h5>
+                <h5 class="mt-2 card-text" title="Price">Price: @NumberFormatter.FormatCurrency(@Model.Data.MostExpensiveGoal.Amount)</h5>
+            </div>
+            <div class="card-footer">
+
+            </div>
+        </div>
+    </div>
+}
+<hr class="mt-5 mb-5" />
+<div data-aos="fade-up">
+    <button class="btn btn-primary mb-4" disabled>Save as an E-Mail<i class="ml-1 far fa-envelope"></i></button>
+</div>
 <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
 <script>
     AOS.init();

--- a/src/Pages/MonthlyReport.cshtml.cs
+++ b/src/Pages/MonthlyReport.cshtml.cs
@@ -1,0 +1,40 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using ePiggyWeb.DataBase;
+using ePiggyWeb.DataManagement.MonthlyReport;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
+
+namespace ePiggyWeb.Pages
+{
+    public class MonthlyReportModel : PageModel
+    {
+        private readonly ILogger<SavingSuggestionsModel> _logger;
+        public bool WasException { get; set; }
+        private int UserId { get; set; }
+
+        public string ErrorMessage = "";
+
+        [BindProperty]
+        public MonthlyReportResult Data { get; set; }
+
+        private GoalDatabase GoalDatabase { get; }
+        private EntryDatabase EntryDatabase { get; }
+
+        public MonthlyReportModel(ILogger<SavingSuggestionsModel> logger, GoalDatabase goalDatabase, EntryDatabase entryDatabase)
+        {
+            _logger = logger;
+            GoalDatabase = goalDatabase;
+            EntryDatabase = entryDatabase;
+        }
+        public async Task<IActionResult> OnGet()
+        {
+            UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
+            var monthlyReportCalculator = new MonthlyReportCalculator(GoalDatabase, EntryDatabase, UserId);
+            Data = await monthlyReportCalculator.Calculate();
+            return Page();
+        }
+
+    }
+}

--- a/src/Pages/MonthlyReport.cshtml.cs
+++ b/src/Pages/MonthlyReport.cshtml.cs
@@ -2,12 +2,14 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using ePiggyWeb.DataBase;
 using ePiggyWeb.DataManagement.MonthlyReport;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 
 namespace ePiggyWeb.Pages
 {
+    [Authorize]
     public class MonthlyReportModel : PageModel
     {
         private readonly ILogger<SavingSuggestionsModel> _logger;

--- a/src/Pages/Register.cshtml
+++ b/src/Pages/Register.cshtml
@@ -2,7 +2,7 @@
 @model ePiggyWeb.Pages.RegisterModel
 
 
-<div class="container login-container col-lg-6 col-md-8 col-sm-10 col-12">
+<div class="container login-container col-lg-4 col-md-8 col-sm-10 col-12">
     <div class="login-form-2">
         <h3>Sign Up</h3>
         <form autocomplete="off" method="post">

--- a/src/Pages/Register.cshtml
+++ b/src/Pages/Register.cshtml
@@ -3,7 +3,7 @@
 
 
 <div class="container login-container col-lg-4 col-md-8 col-sm-10 col-12">
-    <div class="login-form-2">
+    <div class="login-form-2 bg-primary">
         <h3>Sign Up</h3>
         <form autocomplete="off" method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>

--- a/src/Pages/Register.cshtml
+++ b/src/Pages/Register.cshtml
@@ -2,7 +2,7 @@
 @model ePiggyWeb.Pages.RegisterModel
 
 
-<div class="container login-container">
+<div class="container login-container col-lg-6 col-md-8 col-sm-10 col-12">
     <div class="login-form-2">
         <h3>Sign Up</h3>
         <form autocomplete="off" method="post">

--- a/src/Pages/SavingSuggestions.cshtml
+++ b/src/Pages/SavingSuggestions.cshtml
@@ -21,13 +21,14 @@
     <br />
     <hr />
     <form method="get" class="mt-5 mb-5">
-        <input asp-for="Id" type="hidden" value="@Model.Id" />
         <input type="hidden" name="handler" value="Filter" />
-        <label class="text-light">Period:</label>
-        <input for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
-        <label class="text-light"> - </label>
-        <input for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
-        <input type="submit" value="Filter" class="btn btn-warning ml-3" />
+        <label class="text-light col-md-4">Period:</label>
+        <div class="row justify-content-center">
+            <input class="col-md-3 col-sm-5 col-5" for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
+            <label class="text-light ml-2 mr-2"> - </label>
+            <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
+        </div>
+        <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
     <hr />

--- a/src/Pages/SavingSuggestions.cshtml
+++ b/src/Pages/SavingSuggestions.cshtml
@@ -24,6 +24,7 @@
     <br />
     <hr />
     <form method="get" class="mt-5 mb-5">
+        <input asp-for="Id" type="hidden" value="@Model.Id" />
         <input type="hidden" name="handler" value="Filter" />
         <label class="text-light col-md-4">Period:</label>
         <div class="row justify-content-center">
@@ -31,7 +32,7 @@
             <label class="text-light ml-2 mr-2"> - </label>
             <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
         </div>
-        <input type="submit" value="Filter" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3" />
+        <button type="submit" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3">Filter<i class="fas fa-filter"></i></button>
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
     <hr />
@@ -40,13 +41,13 @@
         <p>
             <label class="text-light">Saving type</label><br/>
             <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#minimalSuggestions" aria-expanded="false" aria-controls="minimalSuggestions">
-                Minimal
+                Minimal<i class="ml-1 fas fa-search-minus"></i>
             </button>
             <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#regularSuggestions" aria-expanded="false" aria-controls="regularSuggestions">
-                Regular
+                Regular<i class="ml-1 fas fa-search-dollar"></i>
             </button>
             <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#maximalSuggestions" aria-expanded="false" aria-controls="maximalSuggestions">
-                Maximal
+                Maximal<i class="ml-1 fas fa-search-plus"></i>
             </button>
         </p><hr />
         <!----------------------------MINIMAL----------------------------------------->

--- a/src/Pages/SavingSuggestions.cshtml
+++ b/src/Pages/SavingSuggestions.cshtml
@@ -14,7 +14,10 @@
     <a class="btn btn-sm btn-outline-light" asp-page="/goals"><i class="fas fa-arrow-left"></i> Back to Goals</a>
 </div>
 <h2 class="text-light">@Model.Goal.Title</h2>
-<h3 class="text-light mt-3 mb-4">Currently: @NumberFormatter.FormatCurrency(Model.Savings)/@NumberFormatter.FormatCurrency(Model.Goal.Amount)</h3>
+<h3 class="text-light mt-3 mb-4">
+    Currently: <br/>
+    @NumberFormatter.FormatCurrency(Model.Savings)/@NumberFormatter.FormatCurrency(Model.Goal.Amount)
+</h3>
 
 @if (!Model.WasException)
 {

--- a/src/Pages/SavingSuggestions.cshtml
+++ b/src/Pages/SavingSuggestions.cshtml
@@ -35,7 +35,7 @@
 
     <div class="container mb-5 " id="SavingType">
         <p>
-            <label class="text-light">Saving type</label>
+            <label class="text-light">Saving type</label><br/>
             <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#minimalSuggestions" aria-expanded="false" aria-controls="minimalSuggestions">
                 Minimal
             </button>
@@ -45,49 +45,48 @@
             <button class="btn btn-primary" type="button" data-toggle="collapse" data-target="#maximalSuggestions" aria-expanded="false" aria-controls="maximalSuggestions">
                 Maximal
             </button>
-        </p>
+        </p><hr />
         <!----------------------------MINIMAL----------------------------------------->
         <div class="collapse" id="minimalSuggestions" data-parent="#SavingType">
             <h4 class="text-light">Using suggestions you would need to save for <span class="text-warning">@Model.MinimalSuggestions.TimesToRepeatSaving months</span></h4>
+            <hr />
             <!----------------------------PastedCode----------------------------------------->
-            <div class="container">
-                <h4 class="text-light mb-3">Suggested Expenses improvements (Minimal)</h4>
-                <table class="table table-hover border-primary table-bordered mb-5">
+            <div class="row justify-content-center ml-1 mr-1">
+                <h4 class="text-light mb-2 mt-2">Suggested Expenses improvements (Minimal)</h4>
+                <table class="table table-hover border-primary table-bordered">
                     <tr class="table-primary">
-                        <th>
-                            <label asp-for="MinimalSuggestions.EntrySuggestions.FirstOrDefault().Entry.Title"></label>
+                        <th class="entry-table-side" scope="col">
+                            Expenses
                         </th>
-                        <th style="width: 15%">
-                            <label asp-for="MinimalSuggestions.EntrySuggestions.FirstOrDefault().Entry.Date"></label>
+                        <th scope="col">
+                            Suggested <br />amount
                         </th>
-                        <th style="width: 15%">
-                            <label asp-for="MinimalSuggestions.EntrySuggestions.FirstOrDefault().Entry.Importance"></label>
-                        </th>
-                        <th style="width: 18%">
-                            <label asp-for="MinimalSuggestions.EntrySuggestions.FirstOrDefault().Entry.Amount"></label>
-                        </th>
-                        <th style="width: 18%">
-                            <label class="text-info"><b>Suggested Amount</b></label>
-                        </th>
-
                     </tr>
-
                     @foreach (var item in Model.MinimalSuggestions.EntrySuggestions)
                     {
                         <tr class="table-light border-primary">
-                            <td class="border-primary">
-                                @Html.DisplayFor(m => item.Entry.Title)
+                            <td class="border-primary text-nowrap entry-column">
+                                <div class="row">
+                                    <div class="col-12 mb-2">
+                                        <strong class="text-info">
+                                            @Html.DisplayFor(m => item.Entry.Title)
+                                        </strong>
+                                    </div>
+                                    <div class="col-12 col-md-5 col-lg-4">
+                                        <span class="text-info">Amount:</span>
+                                        @NumberFormatter.FormatCurrency(item.Entry.Amount)
+                                    </div>
+                                    <div class="col-12 col-md-3 col-lg-2">
+                                        <span class="text-info">Date: </span>
+                                        @item.Entry.Date.ToShortDateString()
+                                    </div>
+                                    <div class="col-12 col-md-4">
+                                        <span class="text-info">Importance: </span>
+                                        @((Importance) item.Entry.Importance)
+                                    </div>
+                                </div>
                             </td>
-                            <td class="border-primary">
-                                @item.Entry.Date.ToShortDateString()
-                            </td>
-                            <td class="border-primary">
-                                @((Importance) item.Entry.Importance)
-                            </td>
-                            <td class="border-primary">
-                                @NumberFormatter.FormatCurrency(item.Entry.Amount)
-                            </td>
-                            <td class="border-primary text-info">
+                            <td class="border-primary entry-table-side">
                                 @NumberFormatter.FormatCurrency(item.Amount)
                             </td>
                         </tr>
@@ -95,34 +94,27 @@
                 </table>
             </div>
             <hr />
-            <div class="container">
-                <h4 class="text-light mb-3">Suggested Expenses by category (Minimal)</h4>
-                <table class="table table-hover border-primary table-bordered mt-5">
+            <div class="row justify-content-center ml-1 mr-1">
+                <h4 class="text-light mb-2 mt-2">Suggested Expenses by category (Minimal)</h4>
+                <table class="table table-hover border-primary table-bordered">
                     <tr class="table-primary">
-                        <th>
-                            <label asp-for="MinimalSuggestions.ImportanceSuggestions.FirstOrDefault().Importance"></label>
+                        <th scope="col">
+                            Current
                         </th>
-                        <th>
-                            <label asp-for="MinimalSuggestions.ImportanceSuggestions.FirstOrDefault().OldAverage"></label>
-                        </th>
-                        <th>
-                            <label class="text-info" asp-for="MinimalSuggestions.ImportanceSuggestions.FirstOrDefault().NewAverage"></label>
+                        <th scope="col">
+                           Suggested
                         </th>
                     </tr>
 
                     @foreach (var item in Model.MinimalSuggestions.ImportanceSuggestions)
                     {
                         <tr class="table-light border-primary">
-                            <td class="border-primary">
-                                @Html.DisplayFor(m => item.Importance)
+                            <td class="border-primary entry-column">
+                                <strong class="text-info">@Html.DisplayFor(m => item.Importance)</strong><br />
+                                <span class="text-info"> Amount: </span>@NumberFormatter.FormatCurrency(item.OldAverage)
                             </td>
-                            <td class="border-primary">
-                                @NumberFormatter.FormatCurrency(item.OldAverage)
-                            </td>
-                            <td class="border-primary text-info">
-                                @NumberFormatter.FormatCurrency(item.NewAverage)
-                                <!--Html.DisplayFor(m => item.Date)-->
-                            </td>
+                            <td class="border-primary text-info entry-table-side">
+                            @NumberFormatter.FormatCurrency(item.NewAverage)
                         </tr>
                     }
                 </table>
@@ -133,169 +125,153 @@
         <!----------------------------REGULAR----------------------------------------->
         <div class="collapse" id="regularSuggestions" data-parent="#SavingType">
             <h4 class="text-light">Using suggestions you would need to save for <span class="text-warning">@Model.RegularSuggestions.TimesToRepeatSaving months</span></h4>
+            <hr />
             <!----------------------------PastedCode----------------------------------------->
-            <div class="container">
-                <h4 class="text-light mb-3">Suggested Expenses improvements (Regular)</h4>
-                <table class="table table-hover border-primary table-bordered mb-5">
+            <div class="row justify-content-center ml-1 mr-1">
+                <h4 class="text-light mb-2 mt-2">Suggested Expenses improvements (Regular)</h4>
+                <table class="table table-hover border-primary table-bordered">
                     <tr class="table-primary">
-                        <th>
-                            <label asp-for="RegularSuggestions.EntrySuggestions.FirstOrDefault().Entry.Title"></label>
+                        <th class="entry-table-side" scope="col">
+                            Expenses
                         </th>
-                        <th style="width: 15%">
-                            <label asp-for="RegularSuggestions.EntrySuggestions.FirstOrDefault().Entry.Date"></label>
+                        <th scope="col">
+                            Suggested <br />amount
                         </th>
-                        <th style="width: 15%">
-                            <label asp-for="RegularSuggestions.EntrySuggestions.FirstOrDefault().Entry.Importance"></label>
-                        </th>
-                        <th style="width: 18%">
-                            <label asp-for="RegularSuggestions.EntrySuggestions.FirstOrDefault().Entry.Amount"></label>
-                        </th>
-                        <th style="width: 18%">
-                            <label class="text-info"><b>Suggested Amount</b></label>
-                        </th>
-
                     </tr>
-
                     @foreach (var item in Model.RegularSuggestions.EntrySuggestions)
                     {
                         <tr class="table-light border-primary">
-                            <td class="border-primary">
-                                @Html.DisplayFor(m => item.Entry.Title)
+                            <td class="border-primary text-nowrap entry-column">
+                                <div class="row">
+                                    <div class="col-12 mb-2">
+                                        <strong class="text-info">
+                                            @Html.DisplayFor(m => item.Entry.Title)
+                                        </strong>
+                                    </div>
+                                    <div class="col-12 col-md-5 col-lg-4">
+                                        <span class="text-info">Amount:</span>
+                                        @NumberFormatter.FormatCurrency(item.Entry.Amount)
+                                    </div>
+                                    <div class="col-12 col-md-3 col-lg-2">
+                                        <span class="text-info">Date: </span>
+                                        @item.Entry.Date.ToShortDateString()
+                                    </div>
+                                    <div class="col-12 col-md-4">
+                                        <span class="text-info">Importance: </span>
+                                        @((Importance) item.Entry.Importance)
+                                    </div>
+                                </div>
                             </td>
-                            <td class="border-primary">
-                                @item.Entry.Date.ToShortDateString()
-                            </td>
-                            <td class="border-primary">
-                                @((Importance) item.Entry.Importance)
-                            </td>
-                            <td class="border-primary">
-                                @NumberFormatter.FormatCurrency(item.Entry.Amount)
-                            </td>
-                            <td class="border-primary text-info">
+                            <td class="border-primary entry-table-side">
                                 @NumberFormatter.FormatCurrency(item.Amount)
                             </td>
                         </tr>
                     }
                 </table>
             </div>
-            <hr/>
-            <div class="container">
-                <h4 class="text-light mb-3">Suggested Expenses by category (Regular)</h4>
-                <table class="table table-hover border-primary table-bordered mt-5">
+            <hr />
+            <div class="row justify-content-center ml-1 mr-1">
+                <h4 class="text-light mb-2 mt-2">Suggested Expenses by category (Minimal)</h4>
+                <table class="table table-hover border-primary table-bordered">
                     <tr class="table-primary">
-                        <th>
-                            <label asp-for="RegularSuggestions.ImportanceSuggestions.FirstOrDefault().Importance"></label>
+                        <th scope="col">
+                            Current
                         </th>
-                        <th>
-                            <label asp-for="RegularSuggestions.ImportanceSuggestions.FirstOrDefault().OldAverage"></label>
-                        </th>
-                        <th>
-                            <label class="text-info" asp-for="RegularSuggestions.ImportanceSuggestions.FirstOrDefault().NewAverage"></label>
+                        <th scope="col">
+                            Suggested
                         </th>
                     </tr>
 
                     @foreach (var item in Model.RegularSuggestions.ImportanceSuggestions)
                     {
                         <tr class="table-light border-primary">
-                            <td class="border-primary">
-                                @Html.DisplayFor(m => item.Importance)
+                            <td class="border-primary entry-column">
+                                <strong class="text-info">@Html.DisplayFor(m => item.Importance)</strong><br />
+                                <span class="text-info"> Amount: </span>@NumberFormatter.FormatCurrency(item.OldAverage)
                             </td>
-                            <td class="border-primary">
-                                @NumberFormatter.FormatCurrency(item.OldAverage)
-                            </td>
-                            <td class="border-primary text-info">
+                            <td class="border-primary text-info entry-table-side">
                                 @NumberFormatter.FormatCurrency(item.NewAverage)
-                                <!--Html.DisplayFor(m => item.Date)-->
-                            </td>
                         </tr>
                     }
                 </table>
             </div>
-            <hr/>
+            <hr />
             <!----------------------------PastedCode----------------------------------------->
         </div>
         <!----------------------------MAXIMAL----------------------------------------->
         <div class="collapse" id="maximalSuggestions" data-parent="#SavingType">
             <h4 class="text-light">Using suggestions you would need to save for <span class="text-warning">@Model.MaximalSuggestions.TimesToRepeatSaving months</span></h4>
+            <hr />
             <!----------------------------PastedCode----------------------------------------->
-            <div class="container">
-                <h4 class="text-light mb-3">Suggested Expenses improvements (Maximal)</h4>
-                <table class="table table-hover border-primary table-bordered mb-5">
+            <div class="row justify-content-center ml-1 mr-1">
+                <h4 class="text-light mb-2 mt-2">Suggested Expenses improvements (Maximal)</h4>
+                <table class="table table-hover border-primary table-bordered">
                     <tr class="table-primary">
-                        <th>
-                            <label asp-for="MaximalSuggestions.EntrySuggestions.FirstOrDefault().Entry.Title"></label>
+                        <th class="entry-table-side" scope="col">
+                            Expenses
                         </th>
-                        <th style="width: 15%">
-                            <label asp-for="MaximalSuggestions.EntrySuggestions.FirstOrDefault().Entry.Date"></label>
+                        <th scope="col">
+                            Suggested <br />amount
                         </th>
-                        <th style="width: 15%">
-                            <label asp-for="MaximalSuggestions.EntrySuggestions.FirstOrDefault().Entry.Importance"></label>
-                        </th>
-                        <th style="width: 18%">
-                            <label asp-for="MaximalSuggestions.EntrySuggestions.FirstOrDefault().Entry.Amount"></label>
-                        </th>
-                        <th style="width: 18%">
-                            <label class="text-info"><b>Suggested Amount</b></label>
-                        </th>
-
                     </tr>
-
                     @foreach (var item in Model.MaximalSuggestions.EntrySuggestions)
                     {
                         <tr class="table-light border-primary">
-                            <td class="border-primary">
-                                @Html.DisplayFor(m => item.Entry.Title)
+                            <td class="border-primary text-nowrap entry-column">
+                                <div class="row">
+                                    <div class="col-12 mb-2">
+                                        <strong class="text-info">
+                                            @Html.DisplayFor(m => item.Entry.Title)
+                                        </strong>
+                                    </div>
+                                    <div class="col-12 col-md-5 col-lg-4">
+                                        <span class="text-info">Amount:</span>
+                                        @NumberFormatter.FormatCurrency(item.Entry.Amount)
+                                    </div>
+                                    <div class="col-12 col-md-3 col-lg-2">
+                                        <span class="text-info">Date: </span>
+                                        @item.Entry.Date.ToShortDateString()
+                                    </div>
+                                    <div class="col-12 col-md-4">
+                                        <span class="text-info">Importance: </span>
+                                        @((Importance) item.Entry.Importance)
+                                    </div>
+                                </div>
                             </td>
-                            <td class="border-primary">
-                                @item.Entry.Date.ToShortDateString()
-                            </td>
-                            <td class="border-primary">
-                                @((Importance) item.Entry.Importance)
-                            </td>
-                            <td class="border-primary">
-                                @NumberFormatter.FormatCurrency(item.Entry.Amount)
-                            </td>
-                            <td class="border-primary text-info">
+                            <td class="border-primary entry-table-side">
                                 @NumberFormatter.FormatCurrency(item.Amount)
                             </td>
                         </tr>
                     }
                 </table>
             </div>
-            <hr/>
-            <div class="container">
-                <h4 class="text-light mb-3">Suggested Expenses by category (Maximal)</h4>
-                <table class="table table-hover border-primary table-bordered mt-5">
+            <hr />
+            <div class="row justify-content-center ml-1 mr-1">
+                <h4 class="text-light mb-2 mt-2">Suggested Expenses by category (Maximal)</h4>
+                <table class="table table-hover border-primary table-bordered">
                     <tr class="table-primary">
-                        <th>
-                            <label asp-for="MaximalSuggestions.ImportanceSuggestions.FirstOrDefault().Importance"></label>
+                        <th scope="col">
+                            Current
                         </th>
-                        <th>
-                            <label asp-for="MaximalSuggestions.ImportanceSuggestions.FirstOrDefault().OldAverage"></label>
-                        </th>
-                        <th>
-                            <label class="text-info" asp-for="MaximalSuggestions.ImportanceSuggestions.FirstOrDefault().NewAverage"></label>
+                        <th scope="col">
+                            Suggested
                         </th>
                     </tr>
 
                     @foreach (var item in Model.MaximalSuggestions.ImportanceSuggestions)
                     {
                         <tr class="table-light border-primary">
-                            <td class="border-primary">
-                                @Html.DisplayFor(m => item.Importance)
+                            <td class="border-primary entry-column">
+                                <strong class="text-info">@Html.DisplayFor(m => item.Importance)</strong><br />
+                                <span class="text-info"> Amount: </span>@NumberFormatter.FormatCurrency(item.OldAverage)
                             </td>
-                            <td class="border-primary">
-                                @NumberFormatter.FormatCurrency(item.OldAverage)
-                            </td>
-                            <td class="border-primary text-info">
+                            <td class="border-primary text-info entry-table-side">
                                 @NumberFormatter.FormatCurrency(item.NewAverage)
-                                <!--Html.DisplayFor(m => item.Date)-->
-                            </td>
                         </tr>
                     }
                 </table>
             </div>
-            <hr/>
+            <hr />
             <!----------------------------PastedCode----------------------------------------->
         </div>
     </div>

--- a/src/Pages/Shared/_Layout.cshtml
+++ b/src/Pages/Shared/_Layout.cshtml
@@ -46,8 +46,8 @@
                     Reports
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-                    <a class="dropdown-item" asp-page="/expensesGraph">Expenses</a>
                     <a class="dropdown-item" asp-page="/incomeGraph">Income</a>
+                    <a class="dropdown-item" asp-page="/expensesGraph">Expenses</a>
                     <a class="dropdown-item" asp-page="/comparisonGraph">Comparison</a>
                 </div>
             </li>

--- a/src/Pages/Shared/_Layout.cshtml
+++ b/src/Pages/Shared/_Layout.cshtml
@@ -43,7 +43,7 @@
             </li>
             <li class="nav-item dropdown">
                 <a class="nav-link active dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    Reports
+                    Charts
                 </a>
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                     <a class="dropdown-item" asp-page="/incomeGraph">Income</a>
@@ -51,6 +51,9 @@
                     <div class="dropdown-divider"></div>
                     <a class="dropdown-item" asp-page="/comparisonGraph">Comparison</a>
                 </div>
+            </li>
+            <li class="nav-item active">
+                <a class="nav-link" asp-page="/monthlyreport">Monthly Report<span class="sr-only">(current)</span></a>
             </li>
         </ul>
         <ul class="navbar-nav ml-auto">

--- a/src/Pages/Shared/_Layout.cshtml
+++ b/src/Pages/Shared/_Layout.cshtml
@@ -85,9 +85,10 @@
         </ul>
     </div>
 </nav>
-
+<div class="content">
     @RenderBody()
     @await RenderSectionAsync("Scripts", false)
+</div>
 <div class="container-fluid footer">
         <a href="https://twitter.com/vu_lt" class="footer-image fab fa-twitter"></a>
         <a href="https://www.facebook.com/VilniusUniversity/" class="footer-image fab fa-facebook-f"></a>

--- a/src/Pages/Shared/_Layout.cshtml
+++ b/src/Pages/Shared/_Layout.cshtml
@@ -11,7 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,200;0,300;0,400;1,200&family=Oswald:wght@400;600&display=swap" rel="stylesheet">
     <script src="js/particles.js"></script>
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-</head>
+    <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" /></head>
 
 <body>
     <div id="particles-js"> </div>

--- a/src/Pages/Shared/_Layout.cshtml
+++ b/src/Pages/Shared/_Layout.cshtml
@@ -48,6 +48,7 @@
                 <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                     <a class="dropdown-item" asp-page="/incomeGraph">Income</a>
                     <a class="dropdown-item" asp-page="/expensesGraph">Expenses</a>
+                    <div class="dropdown-divider"></div>
                     <a class="dropdown-item" asp-page="/comparisonGraph">Comparison</a>
                 </div>
             </li>

--- a/src/wwwroot/css/styles.css
+++ b/src/wwwroot/css/styles.css
@@ -224,6 +224,11 @@ body {
 .entry-column {
     text-align: left;
 }
+
+.bigger {
+    width: 20px;
+    height: 20px;
+}
 /*tablets (portrait)*/
 @media (max-width: 1024px) {
 

--- a/src/wwwroot/css/styles.css
+++ b/src/wwwroot/css/styles.css
@@ -229,9 +229,10 @@ body {
     width: 20px;
     height: 20px;
 }
+
 /*tablets (portrait)*/
 @media (max-width: 1024px) {
-
+  
 }
 
 /*smartphones*/

--- a/src/wwwroot/css/styles.css
+++ b/src/wwwroot/css/styles.css
@@ -51,9 +51,8 @@ body {
     color: #f9f7f7;
 }
 
-.title-image {  
+.title-image {
     max-width: 100%;
-    width: 30%;
     height: auto;
 }
 
@@ -103,7 +102,7 @@ body {
 }
 
 .testimonial-image {
-    width: 10%;
+    max-width: 15%;
     border-radius: 100%;
     margin: 3%;
 }
@@ -126,7 +125,6 @@ body {
 /*LOGIN*/
 .login-container {
     padding-top: 5%;
-    max-width: 50%;
     margin-top: 5%;
     margin-bottom: 16%;
     text-align: center;
@@ -221,51 +219,13 @@ body {
 /*tablets (portrait)*/
 @media (max-width: 1024px) {
 
-    .login-container {
-        max-width: 80%;
-        margin-bottom: 25%;
-        margin-top: 12%;
-    }
-
-    .testimonial-image {
-        width: 20%;
-    }
-    .title-image {
-        width: 50%;
-    }
 }
 
 /*smartphones*/
 @media (min-width: 320px) and (max-width: 480px) {
-    .login-container {
-        max-width: 100%;
-        margin-bottom: 40%;
-        margin-top: 20%;
-    }
-
+    
     .testimonial-text {
         font-size: 2rem;
-    }
-
-    .testimonial-image {
-        width: 20%;
-    }
-
-    .title-image {
-        width: 80%;
-    }
-
-    #testimonials {
-        margin-top: 10%;
-    }
-
-    .footer {
-        margin-top: 10%;
-        padding-top: 5%;
-    }
-    .total-graphs {
-        font-size: 1.1rem;
-        font-weight: bold;
     }
 }
 

--- a/src/wwwroot/css/styles.css
+++ b/src/wwwroot/css/styles.css
@@ -25,11 +25,20 @@ html, body {
 }
 
 body {
+    /*Code to make footer stay always at the bottom of page*/
+    display: flex;
+    min-height: 100vh;
+    flex-direction: column; /*END of that code*/
     font-family: Montserrat;
     text-align: center;
     background-color: #276dc1;
 }
 
+.content {
+    flex: 1;
+    /*Code to make footer stay always at the bottom of page*/
+    /*!!!THIS METHOD NOT COMPATIBLE WITH CHROME 27; IE 8;  OPERA 12; SAFARI 8.0*/
+}
 
 #siteHeader {
     margin: 2% 20% 1%;

--- a/src/wwwroot/css/styles.css
+++ b/src/wwwroot/css/styles.css
@@ -216,6 +216,14 @@ body {
     top: 0;
     left: 0
 }
+
+.entry-table-side {
+    vertical-align: middle !important;
+}
+
+.entry-column {
+    text-align: left;
+}
 /*tablets (portrait)*/
 @media (max-width: 1024px) {
 


### PR DESCRIPTION
 - Changed filters in all pages to be mobile responsive.
 - Footer always stays at the bottom and never floats. (NOT COMPATIBLE WITH CHROME 27; IE 8;  OPERA 12; SAFARI 8.0)
 - Validation error when adding goal manually now displayed on separate lines in Modal.
 - Reworked to fit mobile devices: addition of income and expenses.
 - Switched order of charts in dropdown to fit `Finances` dropdown.
 - Removed `@media` code from `CSS` as much as possible and used Bootstraps's grid system. (`col-3; col-md-6` etc.)
 - Mobile responsive expenses table? It is part why I'm creating this pull request without doing this for income. Since only way to solve wide tables on mobile is to make it side-scrollable (as far as I thought about it) and that  is not the best solution. I want you to test it and write here ideas how it could be changed/improved? Since simply making it smaller doesn't make sense (unreadable).

_I've tested everything on Google Chrome. As regular desktop website and as F12 mobile mode on iPhone X and iPad._

PS don't pay attention to the delete button on Expenses table, it was move outside table in preparations to make rows selectable and delete button above table. For now it was placed wherever.