### PR TITLE
Currency Info Caching

### DIFF
--- a/src/Pages/ChangePassword.cshtml.cs
+++ b/src/Pages/ChangePassword.cshtml.cs
@@ -164,6 +164,9 @@ namespace ePiggyWeb.Pages
         public async Task<IActionResult> OnPostDeleteAccount()
         {
             await HttpContext.SignOutAsync();
+            Response.Cookies.Delete("StartDate");
+            Response.Cookies.Delete("EndDate");
+            Cache.Remove(CacheKeys.UserCurrency);
             await UserDatabase.DeleteUserAsync(User.FindFirst(ClaimTypes.Email).Value);
             return Redirect("/index");
         }

--- a/src/Pages/ChangePassword.cshtml.cs
+++ b/src/Pages/ChangePassword.cshtml.cs
@@ -53,6 +53,8 @@ namespace ePiggyWeb.Pages
             CurrencyConverter = currencyConverter;
         }
 
+        // Memory cache - absolute until midnight 
+
         public async Task<IActionResult> OnGet()
         {
             if (!User.Identity.IsAuthenticated)
@@ -66,6 +68,7 @@ namespace ePiggyWeb.Pages
 
         private async Task SetCurrency()
         {
+
             //Some alert could be displayed that failed to get currency list
             var userId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
             UserModel = await UserDatabase.GetUserAsync(userId);

--- a/src/Pages/ComparisonGraph.cshtml
+++ b/src/Pages/ComparisonGraph.cshtml
@@ -24,8 +24,14 @@ else
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
 }
-
-
+@if (Model.CurrencyException)
+{
+    <div class="container">
+        <div class="alert alert-warning" role="alert">
+            We were unable to load <strong>Currencies...</strong><i class="ml-1 fas fa-robot"></i>
+        </div>
+    </div>
+}
 @if (Model.Expenses == 0 && Model.Income == 0)
 {
     <div class="alert alert-warning" role="alert">

--- a/src/Pages/ComparisonGraph.cshtml.cs
+++ b/src/Pages/ComparisonGraph.cshtml.cs
@@ -31,6 +31,7 @@ namespace ePiggyWeb.Pages
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
         public decimal CurrencyRate { get; set; }
+        public bool CurrencyException { get; set; }
         private IMemoryCache Cache { get; }
         public ComparisonGraphModel(EntryDatabase entryDatabase, ILogger<ComparisonGraphModel> logger, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
         {
@@ -64,6 +65,7 @@ namespace ePiggyWeb.Pages
                 {
                     CurrencySymbol = userModel.Currency;
                     CurrencyRate = 1;
+                    CurrencyException = true;
                     return;
                 }
             }

--- a/src/Pages/ComparisonGraph.cshtml.cs
+++ b/src/Pages/ComparisonGraph.cshtml.cs
@@ -7,6 +7,7 @@ using ePiggyWeb.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace ePiggyWeb.Pages
@@ -29,12 +30,15 @@ namespace ePiggyWeb.Pages
         private UserDatabase UserDatabase { get; }
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
-        public ComparisonGraphModel(EntryDatabase entryDatabase, ILogger<ComparisonGraphModel> logger, UserDatabase userDatabase, CurrencyConverter currencyConverter)
+        public decimal CurrencyRate { get; set; }
+        private IMemoryCache Cache { get; }
+        public ComparisonGraphModel(EntryDatabase entryDatabase, ILogger<ComparisonGraphModel> logger, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
         {
             EntryDatabase = entryDatabase;
             _logger = logger;
             UserDatabase = userDatabase;
             CurrencyConverter = currencyConverter;
+            Cache = cache;
         }
 
         public async Task OnGet()
@@ -48,9 +52,26 @@ namespace ePiggyWeb.Pages
 
         private async Task SetCurrency()
         {
-            UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
-            var userModel = await UserDatabase.GetUserAsync(UserId);
-            CurrencySymbol = await CurrencyConverter.GetCurrencySymbol(userModel.Currency);
+            if (!Cache.TryGetValue(CacheKeys.UserCurrency, out Currency userCurrency))
+            {
+                UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
+                var userModel = await UserDatabase.GetUserAsync(UserId);
+                try
+                {
+                    userCurrency = await CurrencyConverter.GetCurrency(userModel.Currency);
+                }
+                catch (Exception)
+                {
+                    CurrencySymbol = userModel.Currency;
+                    CurrencyRate = 1;
+                    return;
+                }
+            }
+
+            CurrencySymbol = userCurrency.GetSymbol();
+            CurrencyRate = userCurrency.Rate;
+            var options = CacheKeys.DefaultCurrencyCacheOptions();
+            Cache.Set(CacheKeys.UserCurrency, userCurrency, options);
         }
 
         public async Task<IActionResult> OnGetFilter(DateTime startDate, DateTime endDate)

--- a/src/Pages/Controllers/LogoutController.cs
+++ b/src/Pages/Controllers/LogoutController.cs
@@ -1,17 +1,27 @@
 ﻿using System.Threading.Tasks;
+using ePiggyWeb.Utilities;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace ePiggyWeb.Pages.Controllers
 {
     public class LogoutController : Controller
     {
+        private IMemoryCache Cache { get; }
+        
+        public LogoutController(IMemoryCache cache)
+        {
+            Cache = cache;
+        }
+
         [HttpPost]
         public async Task<IActionResult> LogoutTask()
         {
             await HttpContext.SignOutAsync();
             Response.Cookies.Delete("StartDate");
             Response.Cookies.Delete("EndDate");
+            Cache.Remove(CacheKeys.UserCurrency);
             return Redirect("/Index");
         }
     }

--- a/src/Pages/Entry.cshtml
+++ b/src/Pages/Entry.cshtml
@@ -4,9 +4,9 @@
 <html>
 <body>
     <h1>Hello Web Pages</h1>
-    <p>@ViewData["EntryList"]</p>
-    <p>@ViewData["IncomeList"]</p>
-    <p>@ViewData["ExpenseList"]</p>
-    <p>@ViewData["GoalList"]</p>
+    <p>@ViewData["Data1"]</p>
+    <p>@ViewData["Data2"]</p>
+    <p>@ViewData["Data3"]</p>
+    <p>@ViewData["Data4"]</p>
 </body>
 </html> 

--- a/src/Pages/Entry.cshtml.cs
+++ b/src/Pages/Entry.cshtml.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using ePiggyWeb.CurrencyAPI;
+using ePiggyWeb.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Caching.Memory;
@@ -13,19 +14,6 @@ using Newtonsoft.Json;
 
 namespace ePiggyWeb.Pages
 {
-    public static class CacheKeys
-    {
-        public static string Entry { get { return "_Entry"; } }
-        public static string CallbackEntry { get { return "_Callback"; } }
-        public static string CallbackMessage { get { return "_CallbackMessage"; } }
-        public static string Parent { get { return "_Parent"; } }
-        public static string Child { get { return "_Child"; } }
-        public static string DependentMessage { get { return "_DependentMessage"; } }
-        public static string DependentCTS { get { return "_DependentCTS"; } }
-        public static string Ticks { get { return "_Ticks"; } }
-        public static string CancelMsg { get { return "_CancelMsg"; } }
-        public static string CancelTokenSource { get { return "_CancelTokenSource"; } }
-    }
 
     public class EntryModel : PageModel
     {
@@ -39,25 +27,6 @@ namespace ePiggyWeb.Pages
             HttpClient = httpClient;
             Configuration = configuration;
             _cache = cache;
-        }
-
-        public void CacheTryGetValueSet()
-        {
-            // Look for cache key.
-            if (!_cache.TryGetValue(CacheKeys.Entry, out DateTime cacheEntry))
-            {
-                // Key not in cache, so get data.
-                cacheEntry = DateTime.Now;
-
-                // Set cache options.
-                var cacheEntryOptions = new MemoryCacheEntryOptions()
-                    // Keep in cache for this time, reset time if accessed.
-                    .SetSlidingExpiration(TimeSpan.FromSeconds(3));
-
-                // Save data in cache.
-                _cache.Set(CacheKeys.Entry, cacheEntry, cacheEntryOptions);
-            }
-
         }
 
         public async Task OnGet()

--- a/src/Pages/Entry.cshtml.cs
+++ b/src/Pages/Entry.cshtml.cs
@@ -1,25 +1,63 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using ePiggyWeb.CurrencyAPI;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 
 namespace ePiggyWeb.Pages
 {
+    public static class CacheKeys
+    {
+        public static string Entry { get { return "_Entry"; } }
+        public static string CallbackEntry { get { return "_Callback"; } }
+        public static string CallbackMessage { get { return "_CallbackMessage"; } }
+        public static string Parent { get { return "_Parent"; } }
+        public static string Child { get { return "_Child"; } }
+        public static string DependentMessage { get { return "_DependentMessage"; } }
+        public static string DependentCTS { get { return "_DependentCTS"; } }
+        public static string Ticks { get { return "_Ticks"; } }
+        public static string CancelMsg { get { return "_CancelMsg"; } }
+        public static string CancelTokenSource { get { return "_CancelTokenSource"; } }
+    }
+
     public class EntryModel : PageModel
     {
 
         private HttpClient HttpClient { get; }
         private IConfiguration Configuration { get; }
+        private IMemoryCache _cache;
 
-        public EntryModel(HttpClient httpClient, IConfiguration configuration)
+        public EntryModel(HttpClient httpClient, IConfiguration configuration, IMemoryCache cache)
         {
             HttpClient = httpClient;
             Configuration = configuration;
+            _cache = cache;
+        }
+
+        public void CacheTryGetValueSet()
+        {
+            // Look for cache key.
+            if (!_cache.TryGetValue(CacheKeys.Entry, out DateTime cacheEntry))
+            {
+                // Key not in cache, so get data.
+                cacheEntry = DateTime.Now;
+
+                // Set cache options.
+                var cacheEntryOptions = new MemoryCacheEntryOptions()
+                    // Keep in cache for this time, reset time if accessed.
+                    .SetSlidingExpiration(TimeSpan.FromSeconds(3));
+
+                // Save data in cache.
+                _cache.Set(CacheKeys.Entry, cacheEntry, cacheEntryOptions);
+            }
+
         }
 
         public async Task OnGet()
@@ -33,7 +71,51 @@ namespace ePiggyWeb.Pages
                 sb.AppendLine(currency.ToString());
             }
 
-            @ViewData["IncomeList"] = sb.ToString();
+            var currencyList = sb.ToString();
+
+
+
+            //var a = 1;
+
+
+            //if (!_cache.TryGetValue("currencyList", out string currencyList))
+            //{
+
+            //    var currencyConverter = new CurrencyConverter(HttpClient, Configuration);
+            //    var list = await currencyConverter.GetList();
+            //    var sb = new StringBuilder();
+
+            //    foreach (var currency in list)
+            //    {
+            //        sb.AppendLine(currency.ToString());
+            //    }
+
+            //    var cacheEntryOptions = new MemoryCacheEntryOptions()
+            //        // Keep in cache for this time, reset time if accessed.
+            //        .SetSlidingExpiration(TimeSpan.FromSeconds(100));
+
+            //    currencyList = sb.ToString();
+
+            //    _cache.Set("currencyList", currencyList, cacheEntryOptions);
+            //}
+
+
+            //    if (!_cache.TryGetValue(CacheKeys.Entry, out DateTime cacheEntry))
+            //{
+            //    // Key not in cache, so get data.
+            //    cacheEntry = DateTime.Now;
+
+            //    // Set cache options.
+            //    var cacheEntryOptions = new MemoryCacheEntryOptions()
+            //        // Keep in cache for this time, reset time if accessed.
+            //        .SetSlidingExpiration(TimeSpan.FromSeconds(1000));
+
+            //    // Save data in cache.
+            //    _cache.Set(CacheKeys.Entry, cacheEntry, cacheEntryOptions);
+            //}
+
+            @ViewData["Data1"] = currencyList;
+            //@ViewData["Data2"] = DateTime.Now.ToLongTimeString();
         }
     }
 }

--- a/src/Pages/Expenses.cshtml
+++ b/src/Pages/Expenses.cshtml
@@ -95,6 +95,14 @@ else
     <hr class="mt-4 mb-4" />
 
 }
+@if (Model.CurrencyException)
+{
+    <div class="container">
+        <div class="alert alert-warning" role="alert">
+            We were unable to load <strong>Currencies...</strong><i class="ml-1 fas fa-robot"></i>
+        </div>
+    </div>
+}
 
 <form method="post">
     <div class="row ml-2 mr-2">
@@ -151,7 +159,6 @@ else
                                 </td>
                                 <td class="border-primary border-left-0 entry-table-side">
                                     <a asp-page="/EditEntry" asp-route-id="@item.Id" asp-route-entryType="2" class="btn btn-sm btn-outline-success"><i class="far fa-edit"></i> </a>
-                                    <!--<input asp-page-handler="Delete" asp-route-id="@item.Id" type="submit" class="btn btn-sm btn-outline-danger" value="x" />-->
                                 </td>
                             </tr>
                         }
@@ -162,7 +169,7 @@ else
         </div>
     </div>
 </form>
-<nav aria-label="Page navigation example">
+<nav aria-label="Page navigation">
     <ul class="pagination justify-content-center">
         <li class="page-item  @(!Model.ShowPrevious ? "disabled" : "")">
             <a class="page-link" asp-page="/expenses" asp-route-CurrentPage="@(Model.CurrentPage - 1)">Previous</a>

--- a/src/Pages/Expenses.cshtml.cs
+++ b/src/Pages/Expenses.cshtml.cs
@@ -64,6 +64,7 @@ namespace ePiggyWeb.Pages
         private CurrencyConverter CurrencyConverter { get; }
         public decimal CurrencyRate { get; set; }
         public string CurrencySymbol { get; private set; }
+        public bool CurrencyException { get; set; }
         private IMemoryCache Cache { get; }
         public ExpensesModel(EntryDatabase entryDatabase, ILogger<ExpensesModel> logger, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
         {
@@ -98,6 +99,7 @@ namespace ePiggyWeb.Pages
                 {
                     CurrencySymbol = userModel.Currency;
                     CurrencyRate = 1;
+                    CurrencyException = true;
                     return;
                 }
             }

--- a/src/Pages/ExpensesGraph.cshtml
+++ b/src/Pages/ExpensesGraph.cshtml
@@ -24,7 +24,14 @@ else
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
 }
-
+@if (Model.CurrencyException)
+{
+    <div class="container">
+        <div class="alert alert-warning" role="alert">
+            We were unable to load <strong>Currencies...</strong><i class="ml-1 fas fa-robot"></i>
+        </div>
+    </div>
+}
 @if (!Model.Expenses.Any())
 {
     <div class="alert alert-warning" role="alert">

--- a/src/Pages/ExpensesGraph.cshtml.cs
+++ b/src/Pages/ExpensesGraph.cshtml.cs
@@ -8,6 +8,7 @@ using ePiggyWeb.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -31,14 +32,17 @@ namespace ePiggyWeb.Pages
         private UserDatabase UserDatabase { get; }
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
+        public decimal CurrencyRate { get; set; }
+        private IMemoryCache Cache { get; }
 
-        public ExpensesGraphModel(EntryDatabase entryDatabase, ILogger<ExpensesGraphModel> logger, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter)
+        public ExpensesGraphModel(EntryDatabase entryDatabase, ILogger<ExpensesGraphModel> logger, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
         {
             EntryDatabase = entryDatabase;
             _logger = logger;
             Configuration = configuration;
             UserDatabase = userDatabase;
             CurrencyConverter = currencyConverter;
+            Cache = cache;
         }
         public async Task OnGet()
         {
@@ -50,9 +54,26 @@ namespace ePiggyWeb.Pages
         }
         private async Task SetCurrency()
         {
-            UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
-            var userModel = await UserDatabase.GetUserAsync(UserId);
-            CurrencySymbol = await CurrencyConverter.GetCurrencySymbol(userModel.Currency);
+            if (!Cache.TryGetValue(CacheKeys.UserCurrency, out Currency userCurrency))
+            {
+                UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
+                var userModel = await UserDatabase.GetUserAsync(UserId);
+                try
+                {
+                    userCurrency = await CurrencyConverter.GetCurrency(userModel.Currency);
+                }
+                catch (Exception)
+                {
+                    CurrencySymbol = userModel.Currency;
+                    CurrencyRate = 1;
+                    return;
+                }
+            }
+
+            CurrencySymbol = userCurrency.GetSymbol();
+            CurrencyRate = userCurrency.Rate;
+            var options = CacheKeys.DefaultCurrencyCacheOptions();
+            Cache.Set(CacheKeys.UserCurrency, userCurrency, options);
         }
 
         public async Task<IActionResult> OnGetFilter(DateTime startDate, DateTime endDate)

--- a/src/Pages/ExpensesGraph.cshtml.cs
+++ b/src/Pages/ExpensesGraph.cshtml.cs
@@ -33,6 +33,7 @@ namespace ePiggyWeb.Pages
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
         public decimal CurrencyRate { get; set; }
+        public bool CurrencyException { get; set; }
         private IMemoryCache Cache { get; }
 
         public ExpensesGraphModel(EntryDatabase entryDatabase, ILogger<ExpensesGraphModel> logger, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
@@ -66,6 +67,7 @@ namespace ePiggyWeb.Pages
                 {
                     CurrencySymbol = userModel.Currency;
                     CurrencyRate = 1;
+                    CurrencyException = true;
                     return;
                 }
             }

--- a/src/Pages/Goals.cshtml
+++ b/src/Pages/Goals.cshtml
@@ -17,6 +17,14 @@ else
     <button type="button" class="btn btn-primary text-light mt-3" data-toggle="modal" data-target="#AddGoalModal">Add Goal<i class="ml-1 fas fa-pencil-alt"></i></button>
     <button type="button" class="btn btn-outline-light mt-3" data-toggle="modal" data-target="#ParseGoalModal">Parse Goal<i class="ml-1 fas fa-cloud-download-alt"></i></button>
 }
+@if (Model.CurrencyException)
+{
+    <div class=" mt-3 container">
+        <div class="alert alert-warning" role="alert">
+            We were unable to load <strong>Currencies...</strong><i class="ml-1 fas fa-robot"></i>
+        </div>
+    </div>
+}
 
 @if (!ModelState.IsValid)
 {
@@ -29,6 +37,7 @@ else
         </div>
     </div>
 }
+
 @if (!Model.Goals.Any())
 {
     <div class=" border container bg-primary mt-5 mb-5">
@@ -94,7 +103,7 @@ else
                         </div>
                     </div>
 
-                    
+
 
                 }
             </div>

--- a/src/Pages/Goals.cshtml.cs
+++ b/src/Pages/Goals.cshtml.cs
@@ -45,6 +45,7 @@ namespace ePiggyWeb.Pages
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
         public decimal CurrencyRate { get; set; }
+        public bool CurrencyException { get; set; }
         private IMemoryCache Cache { get; }
 
         public GoalsModel(GoalDatabase goalDatabase, EntryDatabase entryDatabase, ILogger<GoalsModel> logger, HttpClient httpClient, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
@@ -102,6 +103,8 @@ namespace ePiggyWeb.Pages
                 {
                     CurrencySymbol = userModel.Currency;
                     CurrencyRate = 1;
+                    CurrencyException = true;
+
                     return;
                 }
             }
@@ -190,8 +193,6 @@ namespace ePiggyWeb.Pages
                 WasException = true;
                 return RedirectToPage("/goals");
             }
-            
         }
-
     }
 }

--- a/src/Pages/Goals.cshtml.cs
+++ b/src/Pages/Goals.cshtml.cs
@@ -11,6 +11,7 @@ using ePiggyWeb.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -43,8 +44,10 @@ namespace ePiggyWeb.Pages
         private UserDatabase UserDatabase { get; }
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
+        public decimal CurrencyRate { get; set; }
+        private IMemoryCache Cache { get; }
 
-        public GoalsModel(GoalDatabase goalDatabase, EntryDatabase entryDatabase, ILogger<GoalsModel> logger, HttpClient httpClient, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter)
+        public GoalsModel(GoalDatabase goalDatabase, EntryDatabase entryDatabase, ILogger<GoalsModel> logger, HttpClient httpClient, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
         {
             GoalDatabase = goalDatabase;
             EntryDatabase = entryDatabase;
@@ -54,6 +57,7 @@ namespace ePiggyWeb.Pages
             Configuration = configuration;
             UserDatabase = userDatabase;
             CurrencyConverter = currencyConverter;
+            Cache = cache;
         }
 
         public async Task OnGet()
@@ -86,9 +90,26 @@ namespace ePiggyWeb.Pages
 
         private async Task SetCurrency()
         {
-            UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
-            var userModel = await UserDatabase.GetUserAsync(UserId);
-            CurrencySymbol = await CurrencyConverter.GetCurrencySymbol(userModel.Currency);
+            if (!Cache.TryGetValue(CacheKeys.UserCurrency, out Currency userCurrency))
+            {
+                UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
+                var userModel = await UserDatabase.GetUserAsync(UserId);
+                try
+                {
+                    userCurrency = await CurrencyConverter.GetCurrency(userModel.Currency);
+                }
+                catch (Exception)
+                {
+                    CurrencySymbol = userModel.Currency;
+                    CurrencyRate = 1;
+                    return;
+                }
+            }
+
+            CurrencySymbol = userCurrency.GetSymbol();
+            CurrencyRate = userCurrency.Rate;
+            var options = CacheKeys.DefaultCurrencyCacheOptions();
+            Cache.Set(CacheKeys.UserCurrency, userCurrency, options);
         }
 
         public async Task<IActionResult> OnPostNewGoal()

--- a/src/Pages/Income.cshtml
+++ b/src/Pages/Income.cshtml
@@ -96,6 +96,15 @@ else
     <hr class="mt-4 mb-4" />
 }
 
+@if (Model.CurrencyException)
+{
+    <div class="container">
+        <div class="alert alert-warning" role="alert">
+            We were unable to load <strong>Currencies...</strong><i class="ml-1 fas fa-robot"></i>
+        </div>
+    </div>
+}
+
 <form method="post">
     <div class="row ml-2 mr-2">
         <button asp-page-handler="Delete" type="submit" class="btn btn-danger">Delete Selected <i class="fas fa-trash-alt"></i></button>

--- a/src/Pages/Income.cshtml.cs
+++ b/src/Pages/Income.cshtml.cs
@@ -64,6 +64,7 @@ namespace ePiggyWeb.Pages
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
         public decimal CurrencyRate { get; set; }
+        public bool CurrencyException { get; set; }
         private IMemoryCache Cache { get; }
 
         public IncomesModel(EntryDatabase entryDatabase, ILogger<IncomeModel> logger, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
@@ -99,6 +100,7 @@ namespace ePiggyWeb.Pages
                 {
                     CurrencySymbol = userModel.Currency;
                     CurrencyRate = 1;
+                    CurrencyException = true;
                     return;
                 }
             }

--- a/src/Pages/Income.cshtml.cs
+++ b/src/Pages/Income.cshtml.cs
@@ -12,6 +12,7 @@ using ePiggyWeb.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -62,14 +63,17 @@ namespace ePiggyWeb.Pages
         private UserDatabase UserDatabase { get; }
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
+        public decimal CurrencyRate { get; set; }
+        private IMemoryCache Cache { get; }
 
-        public IncomesModel(EntryDatabase entryDatabase, ILogger<IncomeModel> logger, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter)
+        public IncomesModel(EntryDatabase entryDatabase, ILogger<IncomeModel> logger, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
         {
             EntryDatabase = entryDatabase;
             _logger = logger;
             Configuration = configuration;
             UserDatabase = userDatabase;
             CurrencyConverter = currencyConverter;
+            Cache = cache;
         }
 
         public async Task OnGet()
@@ -83,9 +87,26 @@ namespace ePiggyWeb.Pages
 
         private async Task SetCurrency()
         {
-            UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
-            var userModel = await UserDatabase.GetUserAsync(UserId);
-            CurrencySymbol = await CurrencyConverter.GetCurrencySymbol(userModel.Currency);
+            if (!Cache.TryGetValue(CacheKeys.UserCurrency, out Currency userCurrency))
+            {
+                UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
+                var userModel = await UserDatabase.GetUserAsync(UserId);
+                try
+                {
+                    userCurrency = await CurrencyConverter.GetCurrency(userModel.Currency);
+                }
+                catch (Exception)
+                {
+                    CurrencySymbol = userModel.Currency;
+                    CurrencyRate = 1;
+                    return;
+                }
+            }
+
+            CurrencySymbol = userCurrency.GetSymbol();
+            CurrencyRate = userCurrency.Rate;
+            var options = CacheKeys.DefaultCurrencyCacheOptions();
+            Cache.Set(CacheKeys.UserCurrency, userCurrency, options);
         }
 
         public async Task<IActionResult> OnGetFilter(DateTime startDate, DateTime endDate)

--- a/src/Pages/IncomeGraph.cshtml
+++ b/src/Pages/IncomeGraph.cshtml
@@ -18,10 +18,19 @@ else
         <div class="row justify-content-center">
             <input class="col-md-3 col-sm-5 col-5" for="startDate" asp-for="StartDate" type="date" value="@Model.StartDate.ToShortDateString()" />
             <label class="text-light ml-2 mr-2"> - </label>
-            <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" /></div>
+            <input class="col-md-3 col-sm-5 col-5" for="endDate" asp-for="EndDate" type="date" value="@Model.EndDate.ToShortDateString()" />
+        </div>
         <button type="submit" class="btn btn-warning col-sm-6 col-md-2 col-lg-1 col-4 mt-3">Filter<i class="fas fa-filter"></i></button>
         <p class="text-warning">@Model.ErrorMessage</p>
     </form>
+}
+@if (Model.CurrencyException)
+{
+    <div class="container">
+        <div class="alert alert-warning" role="alert">
+            We were unable to load <strong>Currencies...</strong><i class="ml-1 fas fa-robot"></i>
+        </div>
+    </div>
 }
 
 @if (!Model.Income.Any())

--- a/src/Pages/IncomeGraph.cshtml.cs
+++ b/src/Pages/IncomeGraph.cshtml.cs
@@ -8,6 +8,7 @@ using ePiggyWeb.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -31,13 +32,16 @@ namespace ePiggyWeb.Pages
         private UserDatabase UserDatabase { get; }
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
-        public IncomeGraphModel(EntryDatabase entryDatabase, ILogger<IncomeGraphModel> logger, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter)
+        public decimal CurrencyRate { get; set; }
+        private IMemoryCache Cache { get; }
+        public IncomeGraphModel(EntryDatabase entryDatabase, ILogger<IncomeGraphModel> logger, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
         {
             EntryDatabase = entryDatabase;
             _logger = logger;
             Configuration = configuration;
             UserDatabase = userDatabase;
             CurrencyConverter = currencyConverter;
+            Cache = cache;
         }
         public async Task OnGet()
         {
@@ -50,9 +54,26 @@ namespace ePiggyWeb.Pages
 
         private async Task SetCurrency()
         {
-            UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
-            var userModel = await UserDatabase.GetUserAsync(UserId);
-            CurrencySymbol = await CurrencyConverter.GetCurrencySymbol(userModel.Currency);
+            if (!Cache.TryGetValue(CacheKeys.UserCurrency, out Currency userCurrency))
+            {
+                UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
+                var userModel = await UserDatabase.GetUserAsync(UserId);
+                try
+                {
+                    userCurrency = await CurrencyConverter.GetCurrency(userModel.Currency);
+                }
+                catch (Exception)
+                {
+                    CurrencySymbol = userModel.Currency;
+                    CurrencyRate = 1;
+                    return;
+                }
+            }
+
+            CurrencySymbol = userCurrency.GetSymbol();
+            CurrencyRate = userCurrency.Rate;
+            var options = CacheKeys.DefaultCurrencyCacheOptions();
+            Cache.Set(CacheKeys.UserCurrency, userCurrency, options);
         }
 
         public async Task<IActionResult> OnGetFilter(DateTime startDate, DateTime endDate)

--- a/src/Pages/IncomeGraph.cshtml.cs
+++ b/src/Pages/IncomeGraph.cshtml.cs
@@ -33,6 +33,7 @@ namespace ePiggyWeb.Pages
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
         public decimal CurrencyRate { get; set; }
+        public bool CurrencyException { get; set; }
         private IMemoryCache Cache { get; }
         public IncomeGraphModel(EntryDatabase entryDatabase, ILogger<IncomeGraphModel> logger, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
         {
@@ -66,6 +67,7 @@ namespace ePiggyWeb.Pages
                 {
                     CurrencySymbol = userModel.Currency;
                     CurrencyRate = 1;
+                    CurrencyException = true;
                     return;
                 }
             }

--- a/src/Pages/MonthlyReport.cshtml
+++ b/src/Pages/MonthlyReport.cshtml
@@ -10,6 +10,14 @@
     </div>
     <h1 class="text-warning">Example Goals data used:</h1>
 }
+@if (Model.CurrencyException)
+{
+    <div class="container mt-2">
+        <div class="alert alert-warning" role="alert">
+            We were unable to load <strong>Currencies...</strong><i class="ml-1 fas fa-robot"></i>
+        </div>
+    </div>
+}
 <div data-aos="slide-down">
 
     <h2 class="text-light mt-5 mb-3">Report</h2>
@@ -55,7 +63,8 @@
     {
         <h4 class="text-light"><span class="text-success"><i class="fas fa-dollar-sign"></i></span>You did not have any expenses...</h4>
         <a class="btn btn-primary mt-2" asp-page="/expenses" role="button"><i class="fas fa-hand-holding-usd"></i>To Expenses</a>
-    }else if (Model.Data.NecessarySum >= Model.Data.BiggestCategorySum)
+    }
+    else if (Model.Data.NecessarySum >= Model.Data.BiggestCategorySum)
     {
         <h4 class="text-light"><span class="text-warning"><i class="mr-1 fas fa-award"></i></span>Well done, you've spent most money for the necessary expenses!</h4>
         <h5 class="text-light">@NumberFormatter.FormatCurrency(Model.Data.NecessarySum, Model.CurrencySymbol)</h5>

--- a/src/Pages/MonthlyReport.cshtml.cs
+++ b/src/Pages/MonthlyReport.cshtml.cs
@@ -31,6 +31,7 @@ namespace ePiggyWeb.Pages
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
         public decimal CurrencyRate { get; set; }
+        public bool CurrencyException { get; set; }
         private IMemoryCache Cache { get; }
 
         public MonthlyReportModel(ILogger<SavingSuggestionsModel> logger, GoalDatabase goalDatabase, EntryDatabase entryDatabase, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
@@ -65,6 +66,7 @@ namespace ePiggyWeb.Pages
                 {
                     CurrencySymbol = userModel.Currency;
                     CurrencyRate = 1;
+                    CurrencyException = true;
                     return;
                 }
             }

--- a/src/Pages/MonthlyReport.cshtml.cs
+++ b/src/Pages/MonthlyReport.cshtml.cs
@@ -1,11 +1,14 @@
+using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using ePiggyWeb.CurrencyAPI;
 using ePiggyWeb.DataBase;
 using ePiggyWeb.DataManagement.MonthlyReport;
+using ePiggyWeb.Utilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace ePiggyWeb.Pages
@@ -27,14 +30,17 @@ namespace ePiggyWeb.Pages
         private UserDatabase UserDatabase { get; }
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
+        public decimal CurrencyRate { get; set; }
+        private IMemoryCache Cache { get; }
 
-        public MonthlyReportModel(ILogger<SavingSuggestionsModel> logger, GoalDatabase goalDatabase, EntryDatabase entryDatabase, UserDatabase userDatabase, CurrencyConverter currencyConverter)
+        public MonthlyReportModel(ILogger<SavingSuggestionsModel> logger, GoalDatabase goalDatabase, EntryDatabase entryDatabase, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
         {
             _logger = logger;
             GoalDatabase = goalDatabase;
             EntryDatabase = entryDatabase;
             UserDatabase = userDatabase;
             CurrencyConverter = currencyConverter;
+            Cache = cache;
         }
         public async Task<IActionResult> OnGet()
         {
@@ -47,9 +53,26 @@ namespace ePiggyWeb.Pages
 
         private async Task SetCurrency()
         {
-            UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
-            var userModel = await UserDatabase.GetUserAsync(UserId);
-            CurrencySymbol = await CurrencyConverter.GetCurrencySymbol(userModel.Currency);
+            if (!Cache.TryGetValue(CacheKeys.UserCurrency, out Currency userCurrency))
+            {
+                UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
+                var userModel = await UserDatabase.GetUserAsync(UserId);
+                try
+                {
+                    userCurrency = await CurrencyConverter.GetCurrency(userModel.Currency);
+                }
+                catch (Exception)
+                {
+                    CurrencySymbol = userModel.Currency;
+                    CurrencyRate = 1;
+                    return;
+                }
+            }
+
+            CurrencySymbol = userCurrency.GetSymbol();
+            CurrencyRate = userCurrency.Rate;
+            var options = CacheKeys.DefaultCurrencyCacheOptions();
+            Cache.Set(CacheKeys.UserCurrency, userCurrency, options);
         }
 
     }

--- a/src/Pages/SavingSuggestions.cshtml
+++ b/src/Pages/SavingSuggestions.cshtml
@@ -15,10 +15,17 @@
 </div>
 <h2 class="text-light">@Model.Goal.Title</h2>
 <h3 class="text-light mt-3 mb-4">
-    Currently: <br/>
+    Currently: <br />
     @NumberFormatter.FormatCurrency(Model.Savings, Model.CurrencySymbol)/@NumberFormatter.FormatCurrency(Model.Goal.Amount, Model.CurrencySymbol)
 </h3>
-
+@if (Model.CurrencyException)
+{
+    <div class="container">
+        <div class="alert alert-warning" role="alert">
+            We were unable to load <strong>Currencies...</strong><i class="ml-1 fas fa-robot"></i>
+        </div>
+    </div>
+}
 @if (!Model.WasException)
 {
     <br />
@@ -321,6 +328,4 @@
             }
         </div>
     </div>
-
-    
 }

--- a/src/Pages/SavingSuggestions.cshtml.cs
+++ b/src/Pages/SavingSuggestions.cshtml.cs
@@ -9,6 +9,7 @@ using ePiggyWeb.DataManagement.Saving;
 using ePiggyWeb.Utilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -44,8 +45,10 @@ namespace ePiggyWeb.Pages
         private UserDatabase UserDatabase { get; }
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
+        public decimal CurrencyRate { get; set; }
+        private IMemoryCache Cache { get; }
 
-        public SavingSuggestionsModel(ILogger<SavingSuggestionsModel> logger, GoalDatabase goalDatabase, EntryDatabase entryDatabase, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter)
+        public SavingSuggestionsModel(ILogger<SavingSuggestionsModel> logger, GoalDatabase goalDatabase, EntryDatabase entryDatabase, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
         {
             _logger = logger;
             GoalDatabase = goalDatabase;
@@ -53,6 +56,7 @@ namespace ePiggyWeb.Pages
             Configuration = configuration;
             UserDatabase = userDatabase;
             CurrencyConverter = currencyConverter;
+            Cache = cache;
         }
         public async Task OnGet(int id)
         {
@@ -66,9 +70,26 @@ namespace ePiggyWeb.Pages
 
         private async Task SetCurrency()
         {
-            UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
-            var userModel = await UserDatabase.GetUserAsync(UserId);
-            CurrencySymbol = await CurrencyConverter.GetCurrencySymbol(userModel.Currency);
+            if (!Cache.TryGetValue(CacheKeys.UserCurrency, out Currency userCurrency))
+            {
+                UserId = int.Parse(User.FindFirst(ClaimTypes.Name).Value);
+                var userModel = await UserDatabase.GetUserAsync(UserId);
+                try
+                {
+                    userCurrency = await CurrencyConverter.GetCurrency(userModel.Currency);
+                }
+                catch (Exception)
+                {
+                    CurrencySymbol = userModel.Currency;
+                    CurrencyRate = 1;
+                    return;
+                }
+            }
+
+            CurrencySymbol = userCurrency.GetSymbol();
+            CurrencyRate = userCurrency.Rate;
+            var options = CacheKeys.DefaultCurrencyCacheOptions();
+            Cache.Set(CacheKeys.UserCurrency, userCurrency, options);
         }
 
         public async Task<IActionResult> OnGetFilter(DateTime startDate, DateTime endDate, int id)

--- a/src/Pages/SavingSuggestions.cshtml.cs
+++ b/src/Pages/SavingSuggestions.cshtml.cs
@@ -46,6 +46,7 @@ namespace ePiggyWeb.Pages
         private CurrencyConverter CurrencyConverter { get; }
         public string CurrencySymbol { get; private set; }
         public decimal CurrencyRate { get; set; }
+        public bool CurrencyException { get; set; }
         private IMemoryCache Cache { get; }
 
         public SavingSuggestionsModel(ILogger<SavingSuggestionsModel> logger, GoalDatabase goalDatabase, EntryDatabase entryDatabase, IConfiguration configuration, UserDatabase userDatabase, CurrencyConverter currencyConverter, IMemoryCache cache)
@@ -82,6 +83,7 @@ namespace ePiggyWeb.Pages
                 {
                     CurrencySymbol = userModel.Currency;
                     CurrencyRate = 1;
+                    CurrencyException = true;
                     return;
                 }
             }

--- a/src/Utilities/CacheKeys.cs
+++ b/src/Utilities/CacheKeys.cs
@@ -1,0 +1,8 @@
+﻿namespace ePiggyWeb.Utilities
+{
+    public static class CacheKeys
+    {
+        public static string CurrencyList => "_CurrencyList";
+        public static string UserCurrency => "_UserCurrency";
+    }
+}

--- a/src/Utilities/CacheKeys.cs
+++ b/src/Utilities/CacheKeys.cs
@@ -1,8 +1,19 @@
-﻿namespace ePiggyWeb.Utilities
+﻿using System;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace ePiggyWeb.Utilities
 {
     public static class CacheKeys
     {
         public static string CurrencyList => "_CurrencyList";
         public static string UserCurrency => "_UserCurrency";
+
+        public static MemoryCacheEntryOptions DefaultCurrencyCacheOptions()
+        {
+            var options = new MemoryCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromMinutes(15))
+                .SetAbsoluteExpiration(TimeManager.RefreshTime());
+
+            return options;
+        }
     }
 }

--- a/src/Utilities/TimeManager.cs
+++ b/src/Utilities/TimeManager.cs
@@ -8,7 +8,7 @@ namespace ePiggyWeb.Utilities
     {
         public static DateTime OneMonthAhead { get; }= GetEndOfTheMonth(DateTime.UtcNow.AddMonths(1));
 
-        public static DateTime LocalRefreshTime()
+        public static DateTime RefreshTime()
         {
             var time = DateTime.UtcNow;
 
@@ -19,7 +19,7 @@ namespace ePiggyWeb.Utilities
 
             time = ChangeHour(time, 16);
 
-            return time.ToLocalTime();
+            return time;
         }
 
         public static bool IsDateThisMonthAndLater(DateTime date)

--- a/src/Utilities/TimeManager.cs
+++ b/src/Utilities/TimeManager.cs
@@ -8,6 +8,20 @@ namespace ePiggyWeb.Utilities
     {
         public static DateTime OneMonthAhead { get; }= GetEndOfTheMonth(DateTime.UtcNow.AddMonths(1));
 
+        public static DateTime LocalRefreshTime()
+        {
+            var time = DateTime.UtcNow;
+
+            if (time.Hour >= 16)
+            {
+                time = time.AddDays(1);
+            }
+
+            time = ChangeHour(time, 16);
+
+            return time.ToLocalTime();
+        }
+
         public static bool IsDateThisMonthAndLater(DateTime date)
         {
             return (date.Year == DateTime.UtcNow.Year && date.Month >= DateTime.UtcNow.Month) || date.Year > DateTime.UtcNow.Year;
@@ -75,6 +89,11 @@ namespace ePiggyWeb.Utilities
         {
             var day = DateTime.DaysInMonth(dateTime.Year, dateTime.Month);
             return ChangeDay(dateTime, day);
+        }
+
+        public static DateTime ChangeHour(DateTime dateTime, int newHour)
+        {
+            return dateTime.AddHours(newHour - dateTime.Hour);
         }
 
         public static DateTime ChangeYear(DateTime dateTime, int newYear)


### PR DESCRIPTION
Only review this after looking through the previous API implementation pull request :D 
Implemented caching to give quite a big performance boost and efficiency. The only files to look at are:
 - Change Password: Added caching of the list of currencies, also caches user currency if not already cached
 - Expenses

All the others are just analogues of Expenses or utilities to implement the caching.

Notes:
 - I set the cache to last either 15 minutes sliding, to the (absolute) limit of 16:00 UTC time, because that is the time currency rates refresh
 - When caching, if I don't find the cache and the API doesn't work, I don't cache the backup values (currency codes etc.) that we display
